### PR TITLE
Fix for the River class not having a name property

### DIFF
--- a/pyes/rivers.py
+++ b/pyes/rivers.py
@@ -17,7 +17,8 @@ from es import ESJsonEncoder
 log = logging.getLogger('pyes')
 
 class River(object):
-    def __init__(self, index_name=None, index_type=None, bulk_size=100, bulk_timeout=None):
+    def __init__(self,index_name=None, index_type=None, bulk_size=100, bulk_timeout=None):
+        self.name = index_name 
         self.index_name = index_name
         self.index_type = index_type
         self.bulk_size = bulk_size
@@ -27,6 +28,8 @@ class River(object):
     def q(self):
         res = self.serialize()
         index = {}
+        if self.name:
+            index['name'] = self.name
         if self.index_name:
             index['index'] = self.index_name
         if self.index_type:

--- a/pyes/tests/rivers.py
+++ b/pyes/tests/rivers.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+"""
+from pyestest import *
+from pyes.rivers import *
+
+class RiversTestCase(ESTestCase):
+    def setUp(self):
+        super(RiversTestCase, self).setUp()
+
+    def testCreateCouchDBRiver(self):
+        """
+        Testing deleting a river
+        """
+        test_river = CouchDBRiver(index_name='text_index', index_type='test_type')
+        result = self.conn.create_river(test_river, river_name='test_index')
+        print result
+        self.assertResultContains(result, {'ok': True})
+
+    def testDeleteCouchDBRiver(self):
+        """
+        Testing deleting a river
+        """
+        test_river = CouchDBRiver(index_name='text_index', index_type='test_type')
+        result = self.conn.delete_river(test_river, river_name='test_index')
+        print result
+        self.assertResultContains(result, {'ok': True})
+
+    def testCreateRabbitMQRiver(self):
+        """
+        Testing deleting a river
+        """
+        test_river = RabbitMQRiver(index_name='text_index', index_type='test_type')
+        result = self.conn.create_river(test_river, river_name='test_index')
+        print result
+        self.assertResultContains(result, {'ok': True})
+
+    def testDeleteRabbitMQRiver(self):
+        """
+        Testing deleting a river
+        """
+        test_river = RabbitMQRiver(index_name='text_index', index_type='test_type')
+        result = self.conn.delete_river(test_river, river_name='test_index')
+        print result
+        self.assertResultContains(result, {'ok': True})
+
+    def testCreateTwitterRiver(self):
+        """
+        Testing deleting a river
+        """
+        test_river = TwitterRiver('test', 'test', index_name='text_index', index_type='test_type')
+        result = self.conn.create_river(test_river, river_name='test_index')
+        print result
+        self.assertResultContains(result, {'ok': True})
+
+    def testDeleteTwitterRiver(self):
+        """
+        Testing deleting a river
+        """
+        test_river = TwitterRiver('test', 'test', index_name='text_index', index_type='test_type')
+        result = self.conn.delete_river(test_river, river_name='test_index')
+        print result
+        self.assertResultContains(result, {'ok': True})
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
I have a possible fix for the bug "Using the create_river and delete_river throws an error when used with any of the subclasses."

The River class doesn't have a name property, so I added one. 

The other way to fix this would be to just use the index_name property in the create_river and delete_river methods. I added the property because the name property may be used for other things that are different fromt the index name.
