### PR TITLE
Added "parent" argument to index

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -448,7 +448,7 @@ class ES(object):
         path = self._make_path(parts)
         return self._send_request('GET', path)
 
-    def index(self, doc, index, doc_type, id=None, force_insert=False, bulk=False, querystring_args=None):
+    def index(self, doc, index, doc_type, id=None, parent=None, force_insert=False, bulk=False, querystring_args=None):
         """
         Index a typed JSON document into a specific index and make it searchable.
         """
@@ -462,6 +462,8 @@ class ES(object):
             if force_insert:
                 optype = "create"
             cmd = { optype : { "_index" : index, "_type" : doc_type}}
+            if parent:
+                cmd[optype]['_parent'] = parent
             if id:
                 cmd[optype]['_id'] = id
             self.bulk_data.write(json.dumps(cmd, cls=self.encoder))
@@ -477,6 +479,9 @@ class ES(object):
 
         if force_insert:
             querystring_args['opType'] = 'create'
+        
+        if parent:
+            querystring_args['parent'] = parent
 
         if id is None:
             request_method = 'POST'


### PR DESCRIPTION
Bulk and non-bulk index operations specify the parent in two different ways.  There previously was no way to specify the parent when inserting in bulk mode.  By specifying a "parent" we can easily generate the parameters appropriate for both.  "parent" is a bit generic (and perhaps dangerously close to reserved words) so another option might be "parent_id"
