### PR TITLE
Only require simplejson for python < 2.6

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -5,10 +5,10 @@ __author__ = 'Alberto Paro, Robert Eanes, Matt Dennewitz'
 __all__ = ['ES', 'file_to_attachment', 'decode_json']
 
 try:
-    # For Python < 2.6 or people using a newer version of simplejson
+    # For Python >= 2.6
     import json
 except ImportError:
-    # For Python >= 2.6
+    # For Python < 2.6 or people using a newer version of simplejson
     import simplejson as json
 
 import logging

--- a/pyes/query.py
+++ b/pyes/query.py
@@ -6,9 +6,10 @@ __author__ = 'Alberto Paro'
 import logging
 
 try:
+    # For Python >= 2.6
     import json
 except ImportError:
-    # For Python <= 2.5
+    # For Python < 2.6 or people using a newer version of simplejson
     import simplejson as json
 
 from es import ESJsonEncoder

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ class QuickRunTests(TestCommand):
         TestCommand.run(self, *args, **kwargs)
 
 
-install_requires = ["urllib3", "simplejson"]
+install_requires = ["urllib3"]
+
 #if not sys.platform.startswith("java"):
 #    install_requires += [ "thrift", ]    
 try:
@@ -34,6 +35,12 @@ try:
 except ImportError:
     install_requires.append("importlib")
 
+try:
+    # For Python >= 2.6
+    import json
+except ImportError:
+    # For Python < 2.6 or people using a newer version of simplejson
+    install_requires.append("simplejson")
 
 py_version = sys.version_info
 if not sys.platform.startswith("java") and sys.version_info < (2, 6):


### PR DESCRIPTION
- Change setup.py to only require simplejson if using python < 2.6
- Fixed a few comments around simplejson import to be consistent
