### PR TITLE
Fix for ES.create_index_if_missing()

### DIFF
--- a/pyes/convert_errors.py
+++ b/pyes/convert_errors.py
@@ -17,6 +17,7 @@ import pyes.exceptions
 exceptions_by_name = dict((name, getattr(pyes.exceptions, name))
     for name in (
         'ElasticSearchIllegalArgumentException',
+        'IndexAlreadyExistsException',
         'IndexMissingException',
         'SearchPhaseExecutionException',
         'ReplicationShardOperationFailedException',

--- a/pyes/es.py
+++ b/pyes/es.py
@@ -291,7 +291,7 @@ class ES(object):
         """
         try:
             return self.create_index(index, settings)
-        except pyes.exceptions.AlreadyExistsException, e:
+        except pyes.exceptions.IndexAlreadyExistsException, e:
             return e.result
 
     def delete_index(self, index):

--- a/pyes/exceptions.py
+++ b/pyes/exceptions.py
@@ -7,6 +7,7 @@ __all__ = ['NoServerAvailable',
            "QueryError",
            "NotFoundException",
            "AlreadyExistsException",
+           "IndexAlreadyExistsException",
            "IndexMissingException",
            "SearchPhaseExecutionException",
            "InvalidQuery",
@@ -58,6 +59,9 @@ class NotFoundException(ElasticSearchException):
     pass
 
 class AlreadyExistsException(ElasticSearchException):
+    pass
+
+class IndexAlreadyExistsException(AlreadyExistsException):
     pass
 
 class SearchPhaseExecutionException(ElasticSearchException):

--- a/pyes/tests/errors.py
+++ b/pyes/tests/errors.py
@@ -23,7 +23,7 @@ class ErrorReportingTestCase(ESTestCase):
         self.assertTrue('ok' in result)
         self.assertTrue('error' not in result)
 
-        err = self.checkRaises(pyes.exceptions.AlreadyExistsException,
+        err = self.checkRaises(pyes.exceptions.IndexAlreadyExistsException,
                                self.conn.create_index, "test-index")
         self.assertEqual(str(err), "[test-index] Already exists")
         self.assertEqual(err.status, 400)
@@ -34,10 +34,10 @@ class ErrorReportingTestCase(ESTestCase):
         self.assertTrue('ok' in result)
         self.assertTrue('error' not in result)
 
-        err = self.checkRaises(pyes.exceptions.NotFoundException,
+        err = self.checkRaises(pyes.exceptions.IndexMissingException,
                                self.conn.delete_index, "test-index")
         self.assertEqual(str(err), "[test-index] missing")
-        self.assertEqual(err.status, 400)
+        self.assertEqual(err.status, 404)
         self.assertTrue('error' in err.result)
         self.assertTrue('ok' not in err.result)
 
@@ -48,7 +48,7 @@ class ErrorReportingTestCase(ESTestCase):
         err = self.checkRaises(pyes.exceptions.IndexMissingException,
                                self.conn.flush, 'test-index')
         self.assertEqual(str(err), "[test-index] missing")
-        self.assertEqual(err.status, 500)
+        self.assertEqual(err.status, 404)
         self.assertTrue('error' in err.result)
         self.assertTrue('ok' not in err.result)
 

--- a/pyes/tests/indexing.py
+++ b/pyes/tests/indexing.py
@@ -6,7 +6,7 @@ Unit tests for pyes.  These require an es server with thrift plugin running on t
 import unittest
 from pyes.tests import ESTestCase
 from pyes import TermQuery
-from pyes.exceptions import AlreadyExistsException
+from pyes.exceptions import IndexAlreadyExistsException
 from time import sleep
 
 class IndexingTestCase(ESTestCase):
@@ -65,7 +65,7 @@ class IndexingTestCase(ESTestCase):
 
     def testCannotCreateExistingIndex(self):
         self.conn.create_index("another-index")
-        self.assertRaises(AlreadyExistsException, self.conn.create_index, "another-index")
+        self.assertRaises(IndexAlreadyExistsException, self.conn.create_index, "another-index")
         self.conn.delete_index("another-index")
 
     def testPutMapping(self):


### PR DESCRIPTION
create_index_if_missing() was throwing a generic ElasticSearchException if the index already existed.  Instead of the more specific AlreadyExistsException.  I think this might be a better fix than trying to get AlreadyExistsException working correctly.  It should be backwards compatible.
