### PR TITLE
Fix scan end of iteration

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -752,7 +752,7 @@ class ES(object):
         while True:
             scroll_id = results["_scroll_id"]
             results = self._send_request('GET', "_search/scroll", scroll_id, {"scroll":scroll_timeout})
-            total = results["hits"]["total"]
+            total = len(results["hits"]["hits"])
             if not total:
                 break
             yield results


### PR DESCRIPTION
"total" can no longer be used to determine the end of iteration.  Use the len of hits instead
