### PR TITLE
fix get_mapper.  Remove mapper attribute from ES 

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -142,7 +142,6 @@ class ES(object):
         self.bulk_items = 0
 
         self.info = {} #info about the current server
-        self.mappings = None #track mapping
         self.encoder = encoder
         if self.encoder is None:
             self.encoder = ESJsonEncoder
@@ -543,8 +542,6 @@ class ES(object):
         else:
             path = self._make_path([','.join(indexes), "_mapping"])
         result = self._send_request('GET', path)
-        #processing indexes
-        self.mappings = Mapper(result)
         return result
 
 


### PR DESCRIPTION
Mapper does not work for all mappings and is not used by the ES class.  Remove so as not to break get_mapping.  It can always be created explicitly.
