### PR TITLE
Encode path components

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -19,6 +19,7 @@ import base64
 import time
 from StringIO import StringIO
 from decimal import Decimal
+from urllib import quote
 import copy
 
 try:
@@ -332,7 +333,7 @@ class ES(object):
         """
         Smush together the path components. Empty components will be ignored.
         """
-        path_components = [str(component) for component in path_components if component]
+        path_components = [quote(str(component), "") for component in path_components if component]
         path = '/'.join(path_components)
         if not path.startswith('/'):
             path = '/' + path

--- a/pyes/tests/test_indexing.py
+++ b/pyes/tests/test_indexing.py
@@ -62,6 +62,12 @@ class IndexingTestCase(ESTestCase):
         result = self.conn.delete(self.index_name, self.document_type, 1)
         self.assertResultContains(result, {'_type': 'test-type', '_id': '1', 'ok': True, '_index': 'test-index'})
 
+    def testDeleteByIDWithEncoding(self):
+        self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type, "http://hello/?#'there")
+        self.conn.refresh(self.index_name)
+        result = self.conn.delete(self.index_name, self.document_type, "http://hello/?#'there")
+        self.assertResultContains(result, {'_type': 'test-type', '_id': 'http://hello/?#\'there', 'ok': True, '_index': 'test-index'})
+
     def testDeleteIndex(self):
         self.conn.create_index("another-index")
         result = self.conn.delete_index("another-index")


### PR DESCRIPTION
This patch makes the following change: "Encode path components if necessary. This allows us to index, get, and delete documents with an ID containing special characters like '/', though arbitrary Unicode text is not supported with this patch."

I added a new test case, testDeleteByIDWithEncoding.
