### PR TITLE
Coerce port to int

### DIFF
--- a/pyes/connection_http.py
+++ b/pyes/connection_http.py
@@ -35,7 +35,7 @@ class TimeoutHttpConnectionPool(urllib3.HTTPConnectionPool):
         log.info("Starting new HTTP connection (%d): %s" % (self.num_connections, self.host))
         if sys.version_info < (2, 6):
             return HTTPConnection(host=self.host, port=int(self.port))
-        return HTTPConnection(host=self.host, port=self.port, timeout=self.timeout)
+        return HTTPConnection(host=self.host, port=int(self.port), timeout=self.timeout)
 
 
 class ClientTransport(object):


### PR DESCRIPTION
In versions of Python newer than 2.6 the port was left as a string, which unfortunately causes things to break in eventlet (and possibly other libs).
