### PR TITLE
Handle nested exceptions.

### DIFF
--- a/pyes/convert_errors.py
+++ b/pyes/convert_errors.py
@@ -61,6 +61,10 @@ def raise_if_error(status, result):
         raise pyes.exceptions.ElasticSearchException("Unknown exception type", status, result)
 
     error = result['error']
+    if '; nested: ' in error:
+        error_list = error.split('; nested: ')
+        error = error_list[len(error_list)-1]
+                       
     bits = error.split('[', 1)
     if len(bits) == 2:
         excClass = exceptions_by_name.get(bits[0], None)

--- a/pyes/tests/test_convert_errors.py
+++ b/pyes/tests/test_convert_errors.py
@@ -9,7 +9,9 @@
 import unittest
 
 from pyes.tests import ESTestCase
-from pyes.exceptions import NotFoundException
+from pyes.exceptions import (
+    NotFoundException, IndexAlreadyExistsException
+    )
 import pyes.convert_errors as convert_errors
 
 
@@ -21,6 +23,15 @@ class RaiseIfErrorTestCase(ESTestCase):
             convert_errors.raise_if_error,
             404, {u'_type': u'a_type', u'_id': u'1', u'_index': u'_all'})
 
-
+    def test_nested_index_already_exists_exception(self):
+        self.assertRaises(
+            IndexAlreadyExistsException,
+            convert_errors.raise_if_error,
+            400, {u'status': 400,
+                  u'error': (u'RemoteTransportException[[name][inet' +
+                             u'[/127.0.0.1:9300]][indices/createIndex]]; ' +
+                             u'nested: IndexAlreadyExistsException['+
+                             u'[test-index] Already exists]; ')})
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should resolve https://github.com/aparo/pyes/issues/69. It tries to get the inner-most nested exception and handle it with the usual raise_if_error logic.
