### PR TITLE
Add docs to HighLighter and tweak tests

### DIFF
--- a/pyes/highlight.py
+++ b/pyes/highlight.py
@@ -6,6 +6,22 @@ __author__ = 'Alberto Paro'
 class HighLighter(object):
     """
     This object manage the highlighting
+
+    :arg pre_tags: list of tags before the highlighted text.
+        importance is ordered..  ex. ``['<b>']``
+    :arg post_tags: list of end tags after the highlighted text.
+        should line up with pre_tags.  ex. ``['</b>']``
+    :arg fields: list of fields to highlight
+    :arg fragment_size: the size of the grament
+    :arg number_or_fragments: the maximum number of fragments to
+        return; if 0, then no fragments are returned and instead the
+        entire field is returned and highlighted.
+    :arg fragment_offset: controls the margin to highlight from
+
+    Use this with a :py:class:`pyes.query.Search` like this::
+
+        h = HighLighter('<b>', '</b>')
+        s = Search(TermQuery('foo'), highlight=h)
     """
     def __init__(self, pre_tags=None, post_tags=None, fields=None, fragment_size=None, number_of_fragments=None, fragment_offset=None):
         self.pre_tags = pre_tags

--- a/pyes/tests/test_highlight.py
+++ b/pyes/tests/test_highlight.py
@@ -5,7 +5,7 @@ Unit tests for pyes.  These require an es server with thrift plugin running on t
 """
 import unittest
 from pyes.tests import ESTestCase
-from pyes import Search, StringQuery
+from pyes import Search, StringQuery, HighLighter
 
 class QuerySearchTestCase(ESTestCase):
     def setUp(self):
@@ -43,8 +43,29 @@ class QuerySearchTestCase(ESTestCase):
         q.add_highlight("parsedtext")
         q.add_highlight("name")
         resultset = self.conn.search(q, indices=self.index_name)
+
+        print resultset[0].meta.highlight
+
         self.assertEquals(resultset.total, 2)
         self.assertNotEqual(resultset[0].meta.highlight, None)
+
+        self.assertEquals(resultset[0].meta.highlight[u"parsedtext"][0],
+                          u'<em>Joe</em> Testere nice guy ')
+
+    def test_QueryHighlightWithHighLighter(self):
+        h = HighLighter(['<b>'], ['</b>'])
+        q = Search(StringQuery("joe"), highlight=h)
+        q.add_highlight("parsedtext")
+        q.add_highlight("name")
+        resultset = self.conn.search(q, indices=self.index_name)
+
+        print resultset[0].meta.highlight
+
+        self.assertEquals(resultset.total, 2)
+        self.assertNotEqual(resultset[0].meta.highlight, None)
+
+        self.assertEquals(resultset[0].meta.highlight[u"parsedtext"][0],
+                          u'<b>Joe</b> Testere nice guy ')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The docs say to look at the tests, but there weren't any tests that
changed the pre_tags and post_tags.  This adds tests for that and also
adds some rough documentation which shows up in the autodocs section
of the manual.
