### PR TITLE
Fix typos in HighLighter docs

### DIFF
--- a/pyes/highlight.py
+++ b/pyes/highlight.py
@@ -20,7 +20,7 @@ class HighLighter(object):
 
     Use this with a :py:class:`pyes.query.Search` like this::
 
-        h = HighLighter('<b>', '</b>')
+        h = HighLighter(['<b>'], ['</b>'])
         s = Search(TermQuery('foo'), highlight=h)
     """
     def __init__(self, pre_tags=None, post_tags=None, fields=None, fragment_size=None, number_of_fragments=None, fragment_offset=None):


### PR DESCRIPTION
Just double-checked the docs and noticed I screwed up the example--pre_tags and post_tags need to be lists of tags.  Sorry about that.
