### PR TITLE
Add params to dump_curl() and also make more shell-script friendly.

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -374,9 +374,16 @@ class ES(object):
     def _dump_curl_request(self, request):
         self.dump_curl.write("# [%s]\n" % datetime.now().isoformat())
         self.dump_curl.write("curl -X" + Method._VALUES_TO_NAMES[request.method])
-        self.dump_curl.write(" http://" + self.servers[0] + request.uri)
+        self.dump_curl.write(" '")
+        self.dump_curl.write("http://" + self.servers[0] + request.uri)
+        if request.parameters:
+            params = request.parameters
+            self.dump_curl.write("?")
+            for param in params:
+                self.dump_curl.write("%s=%s" % (param, params[param]))
+        self.dump_curl.write("'")
         if request.body:
-            self.dump_curl.write(" -d \"%s\"" % request.body.replace('"', '\\"'))
+            self.dump_curl.write(" -d '%s'" % request.body.replace("'", "'\\''"))
         self.dump_curl.write("\n")
 
     #---- Admin commands


### PR DESCRIPTION
Small patch with minor changes to dump_curl():
- request parameters are output as a query string;
- make the output slightly more shell-script friendly.

These changes were made whilst preparing an issue to report to the ES mailing-list, since the developers there like issues to be accompanied by a set of cURL commands that will reproduce the problem.
