### PR TITLE
Allow simplejson to be used on python 2.6+

### DIFF
--- a/pyes/convert_errors.py
+++ b/pyes/convert_errors.py
@@ -37,6 +37,7 @@ exception_patterns_trailing = {
     '] Already exists': pyes.exceptions.AlreadyExistsException,
 }
 
+
 def raise_if_error(status, result):
     """Raise an appropriate exception if the result is an error.
 
@@ -45,8 +46,8 @@ def raise_if_error(status, result):
     The exception raised will either be an ElasticSearchException, or a more
     specific subclass of ElasticSearchException if the type is recognised.
 
-    The status code and result can be retrieved from the exception by accessing its
-    status and result properties.
+    The status code and result can be retrieved from the exception by
+    accessing its status and result properties.
 
     """
     assert isinstance(status, int)
@@ -55,16 +56,18 @@ def raise_if_error(status, result):
         return
 
     if status == 404 and isinstance(result, dict) and 'error' not in result:
-        raise pyes.exceptions.NotFoundException("Item not found", status, result)
+        msg = "Item not found"
+        raise pyes.exceptions.NotFoundException(msg, status, result)
 
     if not isinstance(result, dict) or 'error' not in result:
-        raise pyes.exceptions.ElasticSearchException("Unknown exception type", status, result)
+        msg = "Unknown exception type"
+        raise pyes.exceptions.ElasticSearchException(msg, status, result)
 
     error = result['error']
     if '; nested: ' in error:
         error_list = error.split('; nested: ')
-        error = error_list[len(error_list)-1]
-                       
+        error = error_list[len(error_list) - 1]
+
     bits = error.split('[', 1)
     if len(bits) == 2:
         excClass = exceptions_by_name.get(bits[0], None)

--- a/pyes/djangoutils.py
+++ b/pyes/djangoutils.py
@@ -4,7 +4,7 @@
 __author__ = 'Alberto Paro'
 __all__ = ["get_values"]
 
-#useful to raise ad invali import
+#useful to raise an invalid import
 import django
 
 from types import NoneType
@@ -12,10 +12,11 @@ import datetime
 
 #--- taken from http://djangosnippets.org/snippets/2278/
 
+
 def get_values(instance, go_into={}, exclude=(), extra=(), skip_none=False):
     """
     Transforms a django model instance into an object that can be used for
-    serialization. 
+    serialization.
     @param instance(django.db.models.Model) - the model in question
     @param go_into(dict) - relations with other models that need expanding
     @param exclude(tuple) - fields that will be ignored
@@ -77,13 +78,14 @@ def get_values(instance, go_into={}, exclude=(), extra=(), skip_none=False):
         if skip_none and property is None:
             continue
 
-        if field in exclude or field[0] == '_' or isinstance(property, Manager):
-            # if it's in the exclude tuple, ignore it 
-            # if it's a "private" field, ignore it 
+        if field in exclude or field[0] == '_' or isinstance(property,
+                                                             Manager):
+            # if it's in the exclude tuple, ignore it
+            # if it's a "private" field, ignore it
             # if it's an instance of manager (this means a more complicated
-            # relationship), ignore it 
+            # relationship), ignore it
             continue
-        elif go_into.has_key(field):
+        elif field in go_into:
             # if it's in the go_into dict, make a recursive call for that field
             try:
                 field_go_into = go_into[field].get('go_into', {})

--- a/pyes/exceptions.py
+++ b/pyes/exceptions.py
@@ -24,6 +24,7 @@ __all__ = ['NoServerAvailable',
            'DocumentAlreadyExistsEngineException'
           ]
 
+
 class NoServerAvailable(Exception):
     pass
 
@@ -31,20 +32,26 @@ class NoServerAvailable(Exception):
 class InvalidQuery(Exception):
     pass
 
+
 class InvalidParameterQuery(InvalidQuery):
     pass
+
 
 class QueryError(Exception):
     pass
 
+
 class QueryParameterError(Exception):
     pass
+
 
 class ScriptFieldsError(Exception):
     pass
 
+
 class InvalidParameter(Exception):
     pass
+
 
 class ElasticSearchException(Exception):
     """Base class of exceptions raised as a result of parsing an error return
@@ -59,39 +66,50 @@ class ElasticSearchException(Exception):
         self.status = status
         self.result = result
 
+
 class ElasticSearchIllegalArgumentException(ElasticSearchException):
     pass
+
 
 class IndexMissingException(ElasticSearchException):
     pass
 
+
 class NotFoundException(ElasticSearchException):
     pass
+
 
 class AlreadyExistsException(ElasticSearchException):
     pass
 
+
 class IndexAlreadyExistsException(AlreadyExistsException):
     pass
+
 
 class SearchPhaseExecutionException(ElasticSearchException):
     pass
 
+
 class ReplicationShardOperationFailedException(ElasticSearchException):
     pass
+
 
 class ClusterBlockException(ElasticSearchException):
     pass
 
+
 class MapperParsingException(ElasticSearchException):
     pass
+
 
 class ReduceSearchPhaseException(ElasticSearchException):
     pass
 
+
 class VersionConflictEngineException(ElasticSearchException):
     pass
 
+
 class DocumentAlreadyExistsEngineException(ElasticSearchException):
     pass
-

--- a/pyes/facets.py
+++ b/pyes/facets.py
@@ -5,6 +5,7 @@ __author__ = 'Alberto Paro'
 
 from utils import EqualityComparableUsingAttributeDictionary
 
+
 #--- Facet
 class FacetFactory(EqualityComparableUsingAttributeDictionary):
     def __init__(self):
@@ -23,11 +24,13 @@ class FacetFactory(EqualityComparableUsingAttributeDictionary):
         res = {}
         for facet in self.facets:
             res.update(facet.serialize())
-        return {"facets":res}
+        return {"facets": res}
+
 
 class Facet(EqualityComparableUsingAttributeDictionary):
     def __init__(self, *args, **kwargs):
         pass
+
 
 class QueryFacet(Facet):
     _internal_name = "query"
@@ -38,7 +41,8 @@ class QueryFacet(Facet):
         self.query = query
 
     def serialize(self):
-        return {self.name:{self._internal_name:self.query.serialize()}}
+        return {self.name: {self._internal_name: self.query.serialize()}}
+
 
 class FilterFacet(Facet):
     _internal_name = "filter"
@@ -49,7 +53,8 @@ class FilterFacet(Facet):
         self.query = query
 
     def serialize(self):
-        return {self.name:{self._internal_name:self.query.serialize()}}
+        return {self.name: {self._internal_name: self.query.serialize()}}
+
 
 class HistogramFacet(Facet):
     _internal_name = "histogram"
@@ -76,7 +81,8 @@ class HistogramFacet(Facet):
         elif self.time_interval:
             data['time_interval'] = self.time_interval
         else:
-            raise RuntimeError("Invalid field: interval or time_interval required")
+            raise RuntimeError("Invalid field: interval or time_interval "
+                               "required")
 
     def serialize(self):
         data = {}
@@ -100,7 +106,8 @@ class HistogramFacet(Facet):
             if self.params:
                 data['params'] = self.params
 
-        return {self.name:{self._internal_name:data}}
+        return {self.name: {self._internal_name: data}}
+
 
 class DateHistogramFacet(Facet):
     _internal_name = "date_histogram"
@@ -140,9 +147,11 @@ class DateHistogramFacet(Facet):
                 if self.params:
                     data['params'] = self.params
             else:
-                raise RuntimeError("Invalid key_field: value_field or value_script required")
+                raise RuntimeError("Invalid key_field: value_field or "
+                                   "value_script required")
 
-        return {self.name:{self._internal_name:data}}
+        return {self.name: {self._internal_name: data}}
+
 
 class RangeFacet(Facet):
     _internal_name = "range"
@@ -188,7 +197,8 @@ class RangeFacet(Facet):
             if self.params:
                 data['params'] = self.params
 
-        return {self.name:{self._internal_name:data}}
+        return {self.name: {self._internal_name: data}}
+
 
 class StatisticalFacet(Facet):
     _internal_name = "statistical"
@@ -210,7 +220,8 @@ class StatisticalFacet(Facet):
             if self.params:
                 data['params'] = self.params
 
-        return {self.name:{self._internal_name:data}}
+        return {self.name: {self._internal_name: data}}
+
 
 class TermFacet(Facet):
     _internal_name = "terms"
@@ -234,18 +245,20 @@ class TermFacet(Facet):
 
     def serialize(self):
         if self.fields:
-            data = {'fields':self.fields}
+            data = {'fields': self.fields}
         else:
             if self.field:
-                data = {'field':self.field}
+                data = {'field': self.field}
             else:
-                raise RuntimeError("Field or Fields is required:%s" % self.order)
+                msg = "Field or Fields is required:%s" % self.order
+                raise RuntimeError(msg)
 
         if self.size:
             data['size'] = self.size
 
         if self.order:
-            if self.order not in ['count', 'term', 'reverse_count', 'reverse_term']:
+            if self.order not in ('count', 'term', 'reverse_count',
+                                  'reverse_term'):
                 raise RuntimeError("Invalid order value:%s" % self.order)
             data['order'] = self.order
         if self.exclude:
@@ -257,4 +270,4 @@ class TermFacet(Facet):
         elif self.script:
             data['script'] = self.script
 
-        return {self.name:{self._internal_name:data}}
+        return {self.name: {self._internal_name: data}}

--- a/pyes/fakettypes.py
+++ b/pyes/fakettypes.py
@@ -3,6 +3,7 @@
 
 __author__ = 'Alberto Paro'
 
+
 #
 # Fake ttypes to use in http protocol to simulate thrift ones
 #
@@ -32,6 +33,7 @@ class Method:
                         "HEAD": 4,
                         "OPTIONS": 5,
                       }
+
 
 class Status:
     CONTINUE = 100
@@ -173,6 +175,7 @@ class Status:
       "INSUFFICIENT_STORAGE": 506,
     }
 
+
 class RestRequest(object):
     """
     Attributes:
@@ -183,12 +186,14 @@ class RestRequest(object):
      - body
     """
 
-    def __init__(self, method=None, uri=None, parameters=None, headers=None, body=None):
+    def __init__(self, method=None, uri=None, parameters=None, headers=None,
+                 body=None):
         self.method = method
         self.uri = uri
         self.parameters = parameters
         self.headers = headers
         self.body = body
+
 
 class RestResponse:
     """
@@ -201,5 +206,3 @@ class RestResponse:
         self.status = status
         self.headers = headers
         self.body = body
-
-

--- a/pyes/helpers.py
+++ b/pyes/helpers.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
 class SettingsBuilder(object):
     def __init__(self, settings=None, mappings=None):
-        self.settings = settings or {'index.number_of_replicas':1,
+        self.settings = settings or {"index.number_of_replicas": 1,
                                      "index.number_of_shards": 5}
         self.mappings = mappings or {}
 
@@ -22,5 +23,5 @@ class SettingsBuilder(object):
 
     def as_dict(self):
         """Returns a dict"""
-        return {"settings":self.settings,
-                "mappings":self.mappings}
+        return {"settings": self.settings,
+                "mappings": self.mappings}

--- a/pyes/highlight.py
+++ b/pyes/highlight.py
@@ -3,6 +3,7 @@
 
 __author__ = 'Alberto Paro'
 
+
 class HighLighter(object):
     """
     This object manage the highlighting
@@ -23,7 +24,9 @@ class HighLighter(object):
         h = HighLighter(['<b>'], ['</b>'])
         s = Search(TermQuery('foo'), highlight=h)
     """
-    def __init__(self, pre_tags=None, post_tags=None, fields=None, fragment_size=None, number_of_fragments=None, fragment_offset=None):
+    def __init__(self, pre_tags=None, post_tags=None, fields=None,
+                 fragment_size=None, number_of_fragments=None,
+                 fragment_offset=None):
         self.pre_tags = pre_tags
         self.post_tags = post_tags
         self.fields = fields or {}
@@ -31,7 +34,8 @@ class HighLighter(object):
         self.number_of_fragments = number_of_fragments
         self.fragment_offset = fragment_offset
 
-    def add_field(self, name, fragment_size=150, number_of_fragments=3, fragment_offset=None):
+    def add_field(self, name, fragment_size=150, number_of_fragments=3,
+                  fragment_offset=None):
         """
         Add a field to Highlinghter
         """
@@ -59,5 +63,5 @@ class HighLighter(object):
         if self.fields:
             res["fields"] = self.fields
         else:
-            res["fields"] = {"_all" : {}}
+            res["fields"] = {"_all": {}}
         return res

--- a/pyes/mappings.py
+++ b/pyes/mappings.py
@@ -11,11 +11,12 @@ from pyes.utils import keys_to_string
 
 check_values = {
                 'index': ['no', 'analyzed', 'not_analyzed'],
-                'term_vector': ['no', 'yes', 'with_offsets', 'with_positions', 'with_positions_offsets'],
+                'term_vector': ['no', 'yes', 'with_offsets',
+                                'with_positions', 'with_positions_offsets'],
                 'type': ['float', 'double', 'short', 'integer', 'long'],
                 'store': ['yes', 'no'],
-                'index_analyzer' : [],
-                'search_analyzer' : [],
+                'index_analyzer': [],
+                'search_analyzer': [],
                 }
 
 
@@ -42,8 +43,8 @@ class AbstractField(object):
         self.name = name
 
     def as_dict(self):
-        result = {"type":self.type,
-                  'index':self.index}
+        result = {"type": self.type,
+                  'index': self.index}
         if self.store != "no":
             if isinstance(self.store, bool):
                 if self.store:
@@ -59,7 +60,8 @@ class AbstractField(object):
         if self.omit_norms != True:
             result['omit_norms'] = self.omit_norms
         if self.omit_term_freq_and_positions != True:
-            result['omit_term_freq_and_positions'] = self.omit_term_freq_and_positions
+            omit_term_freq_and_pos = self.omit_term_freq_and_positions
+            result['omit_term_freq_and_positions'] = omit_term_freq_and_pos
         if self.index_name:
             result['index_name'] = self.index_name
         if self.analyzer:
@@ -70,6 +72,7 @@ class AbstractField(object):
             result['search_analyzer'] = self.search_analyzer
 
         return result
+
 
 class StringField(AbstractField):
     def __init__(self, null_value=None, include_in_all=None, *args, **kwargs):
@@ -85,6 +88,7 @@ class StringField(AbstractField):
         if self.include_in_all is not None:
             result['include_in_all'] = self.include_in_all
         return result
+
 
 class GeoPointField(AbstractField):
     def __init__(self, null_value=None, include_in_all=None,
@@ -116,6 +120,7 @@ class GeoPointField(AbstractField):
             result['geohash_precision'] = self.geohash_precision
         return result
 
+
 class NumericFieldAbstract(AbstractField):
     def __init__(self, null_value=None, include_in_all=None, precision_step=4,
                  **kwargs):
@@ -134,35 +139,42 @@ class NumericFieldAbstract(AbstractField):
             result['precision_step'] = self.precision_step
         return result
 
+
 class IpField(NumericFieldAbstract):
     def __init__(self, *args, **kwargs):
         super(IpField, self).__init__(*args, **kwargs)
         self.type = "ip"
+
 
 class ShortField(NumericFieldAbstract):
     def __init__(self, *args, **kwargs):
         super(ShortField, self).__init__(*args, **kwargs)
         self.type = "short"
 
+
 class IntegerField(NumericFieldAbstract):
     def __init__(self, *args, **kwargs):
         super(IntegerField, self).__init__(*args, **kwargs)
         self.type = "integer"
+
 
 class LongField(NumericFieldAbstract):
     def __init__(self, *args, **kwargs):
         super(LongField, self).__init__(*args, **kwargs)
         self.type = "long"
 
+
 class FloatField(NumericFieldAbstract):
     def __init__(self, *args, **kwargs):
         super(FloatField, self).__init__(*args, **kwargs)
         self.type = "float"
 
+
 class DoubleField(NumericFieldAbstract):
     def __init__(self, *args, **kwargs):
         super(DoubleField, self).__init__(*args, **kwargs)
         self.type = "double"
+
 
 class DateField(NumericFieldAbstract):
     def __init__(self, format=None, **kwargs):
@@ -175,6 +187,7 @@ class DateField(NumericFieldAbstract):
         if self.format:
             result['format'] = self.format
         return result
+
 
 class BooleanField(AbstractField):
     def __init__(self, null_value=None, include_in_all=None, *args, **kwargs):
@@ -191,6 +204,7 @@ class BooleanField(AbstractField):
             result['include_in_all'] = self.include_in_all
         return result
 
+
 class MultiField(object):
     def __init__(self, name, type=None, path=None, fields=None):
         self.name = name
@@ -198,7 +212,8 @@ class MultiField(object):
         self.path = path
         self.fields = {}
         if fields and isinstance(fields, dict):
-            self.fields = dict([(name, get_field(name, data)) for name, data in fields.items()])
+            self.fields = dict([(name, get_field(name, data))
+                                 for name, data in fields.items()])
 
     def as_dict(self):
         result = {"type": self.type,
@@ -210,6 +225,7 @@ class MultiField(object):
             result['path'] = self.path
         return result
 
+
 class AttachmentField(object):
     """An attachment field.
 
@@ -220,7 +236,8 @@ class AttachmentField(object):
         self.name = name
         self.type = "attachment"
         self.path = path
-        self.fields = dict([(name, get_field(name, data)) for name, data in fields.items()])
+        self.fields = dict([(name, get_field(name, data))
+                             for name, data in fields.items()])
 
     def as_dict(self):
         result_fields = dict((name, value.as_dict())
@@ -230,11 +247,12 @@ class AttachmentField(object):
             result['path'] = self.path
         return result
 
+
 class ObjectField(object):
     def __init__(self, name=None, type=None, path=None, properties=None,
-                 dynamic=None, enabled=None, include_in_all=None, dynamic_templates=None,
-                 _id=False, _type=False, _source=None, _all=None,
-                 _analyzer=None, _boost=None,
+                 dynamic=None, enabled=None, include_in_all=None,
+                 dynamic_templates=None, _id=False, _type=False,
+                 _source=None, _all=None, _analyzer=None, _boost=None,
                  _parent=None, _index=None, _routing=None):
         self.name = name
         self.type = "object"
@@ -254,7 +272,8 @@ class ObjectField(object):
         self._index = _index
         self._routing = _routing
         if properties:
-            self.properties = dict([(name, get_field(name, data)) for name, data in properties.items()])
+            self.properties = dict([(name, get_field(name, data))
+                                     for name, data in properties.items()])
         else:
             self.properties = {}
 
@@ -268,9 +287,9 @@ class ObjectField(object):
         result = {"type": self.type,
                   "properties": {}}
         if self._id:
-            result['_id'] = {"store":True}
+            result['_id'] = {"store": True}
         if self._type:
-            result['_type'] = {"store":True}
+            result['_type'] = {"store": True}
         if self._source is not None:
             result['_source'] = self._source
         if self._all is not None:
@@ -282,7 +301,7 @@ class ObjectField(object):
         if self._parent is not None:
             result['_parent'] = self._parent
         if self._index:
-            result['_index'] = {"store":True}
+            result['_index'] = {"store": True}
         if self._routing is not None:
             result['_routing'] = self._routing
         if self.dynamic is not None:
@@ -301,6 +320,7 @@ class ObjectField(object):
 
     def __str__(self):
         return str(self.as_dict())
+
 
 class DocumentObjectField(object):
     def __init__(self, name=None, type=None, path=None, properties=None,
@@ -322,7 +342,8 @@ class DocumentObjectField(object):
         self._parent = _parent
         self.date_formats = date_formats
         if properties:
-            self.properties = dict([(name, get_field(name, data)) for name, data in properties.items()])
+            self.properties = dict([(name, get_field(name, data))
+                                    for name, data in properties.items()])
 
     def as_dict(self):
         result = {"type": self.type,
@@ -355,6 +376,7 @@ class DocumentObjectField(object):
 
     def __unicode__(self):
         return "<DocumentObjectField:%s>" % self.as_dict()
+
 
 def get_field(name, data):
     """
@@ -395,6 +417,7 @@ def get_field(name, data):
         return ObjectField(name=name, **data)
     raise RuntimeError("Invalid type: %s" % type)
 
+
 class Mapper(object):
     def __init__(self, data, is_mapping=False):
         self.indices = {}
@@ -413,7 +436,8 @@ class Mapper(object):
             for indexname, indexdata in data.items():
                 self.indices[indexname] = {}
                 for docname, docdata in indexdata.items():
-                    self.indices[indexname][docname] = get_field(docname, docdata)
+                    self.indices[indexname][docname] = get_field(docname,
+                                                                 docdata)
 
     def get_doctype(self, index, name):
         """

--- a/pyes/rivers.py
+++ b/pyes/rivers.py
@@ -17,8 +17,10 @@ from es import ESJsonEncoder
 
 log = logging.getLogger('pyes')
 
+
 class River(object):
-    def __init__(self, index_name=None, index_type=None, bulk_size=100, bulk_timeout=None):
+    def __init__(self, index_name=None, index_type=None, bulk_size=100,
+                 bulk_timeout=None):
         self.name = index_name
         self.index_name = index_name
         self.index_type = index_type
@@ -49,6 +51,7 @@ class River(object):
     def to_json(self):
         return json.dumps(self.q, cls=ESJsonEncoder)
 
+
 class RabbitMQRiver(River):
     type = "rabbitmq"
 
@@ -66,19 +69,15 @@ class RabbitMQRiver(River):
         self.routing_key = routing_key
 
     def serialize(self):
-        return {
-                "type" : self.type,
-                self.type : {
-                    "host" : self.host,
-                    "port" : self.port,
-                    "user" : self.user,
-                    "pass" : self.password,
-                    "vhost" : self.vhost,
-                    "queue" : self.queue,
-                    "exchange" : self.exchange,
-                    "routing_key" : self.routing_key
-                }
-            }
+        return {"type": self.type,
+                self.type: {"host": self.host,
+                             "port": self.port,
+                             "user": self.user,
+                             "pass": self.password,
+                             "vhost": self.vhost,
+                             "queue": self.queue,
+                             "exchange": self.exchange,
+                             "routing_key": self.routing_key}}
 
 
 class TwitterRiver(River):
@@ -89,20 +88,17 @@ class TwitterRiver(River):
         self.user = user
         self.password = password
 
-
     def serialize(self):
-        return {
-                "type" : self.type,
-                self.type : {
-                    "user" : self.user,
-                    "password" : self.password,
-                }
-            }
+        return {"type": self.type,
+                self.type: {"user": self.user,
+                            "password": self.password}}
+
 
 class CouchDBRiver(River):
     type = "couchdb"
 
-    def __init__(self, host="localhost", port=5984, db="mydb", filter=None, filter_params=None, script=None, **kwargs):
+    def __init__(self, host="localhost", port=5984, db="mydb", filter=None,
+                 filter_params=None, script=None, **kwargs):
         super(CouchDBRiver, self).__init__(**kwargs)
         self.host = host
         self.port = port
@@ -112,15 +108,11 @@ class CouchDBRiver(River):
         self.script = script
 
     def serialize(self):
-        result = {
-                "type" : self.type,
-                self.type : {
-                    "host" : self.host,
-                    "port" : self.port,
-                    "db" : self.db,
-                    "filter" : self.filter,
-                }
-            }
+        result = {"type": self.type,
+                  self.type: {"host": self.host,
+                              "port": self.port,
+                              "db": self.db,
+                              "filter": self.filter}}
         if self.filter_params is not None:
             result[self.type]["filter_params"] = self.filter_params
         if self.script is not None:

--- a/pyes/scriptfields.py
+++ b/pyes/scriptfields.py
@@ -5,16 +5,18 @@ __author__ = 'Armando Guereca'
 
 from pyes.exceptions import ScriptFieldsError
 
+
 class ScriptFields(object):
     """
     This object create the script_fields definition
     """
     _internal_name = "script_fields"
-    def __init__(self, field_name, script, params = None):
-        self.fields={}
+
+    def __init__(self, field_name, script, params=None):
+        self.fields = {}
         self.add_field(field_name, script, params or {})
 
-    def add_field(self, field_name, script, params = None):
+    def add_field(self, field_name, script, params=None):
         """
         Add a field to script_fields
         """
@@ -22,13 +24,15 @@ class ScriptFields(object):
         if script:
             data['script'] = script
         else:
-            raise ScriptFieldsError("Script is required for script_fields definition")
+            raise ScriptFieldsError("Script is required for script_fields "
+                                    "definition")
         if params:
             if isinstance(params, dict):
                 if len(params):
                     data['params'] = params
             else:
-                raise ScriptFieldsError("Parameters should be a valid dictionary")
+                raise ScriptFieldsError("Parameters should be a valid "
+                                        "dictionary")
 
         self.fields[field_name] = data
 
@@ -36,12 +40,14 @@ class ScriptFields(object):
         """
         Add a parameter to a field into script_fields
 
-        The ScriptFields object will be returned, so calls to this can be chained.
+        The ScriptFields object will be returned, so calls to this can be
+        chained.
         """
         try:
             self.fields[field_name]['params'][param_name] = param_value
         except Exception as ex:
-            raise ScriptFieldsError("Error adding parameter %s with value %s :%s" % (param_name,param_value,ex))
+            msg = "Error adding parameter %s with value %s :%s"
+            raise ScriptFieldsError(msg % (param_name, param_value, ex))
 
         return self
 

--- a/pyes/tests/__init__.py
+++ b/pyes/tests/__init__.py
@@ -1,16 +1,18 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 from pyestest import ESTestCase, get_conn
+
 
 def setUp():
     """Package level setup.
 
-    For tests which don't modify the index, we don't want to have the overhead
-    of setting up a test index, so we just set up test-pindex once, and use it
-    for all tests.
+    For tests which don't modify the index, we don't want to have the
+    overhead of setting up a test index, so we just set up test-pindex once,
+    and use it for all tests.
 
     """
     mapping = {
@@ -19,19 +21,19 @@ def setUp():
             'index': 'analyzed',
             'store': 'yes',
             'type': u'string',
-            "term_vector" : "with_positions_offsets"},
+            "term_vector": "with_positions_offsets"},
         u'name': {
             'boost': 1.0,
             'index': 'analyzed',
             'store': 'yes',
             'type': u'string',
-            "term_vector" : "with_positions_offsets"},
+            "term_vector": "with_positions_offsets"},
         u'title': {
             'boost': 1.0,
             'index': 'analyzed',
             'store': 'yes',
             'type': u'string',
-            "term_vector" : "with_positions_offsets"},
+            "term_vector": "with_positions_offsets"},
         u'pos': {
             'store': 'yes',
             'type': u'integer'},
@@ -43,14 +45,23 @@ def setUp():
             'index': 'not_analyzed',
             'store': 'yes',
             'type': u'string'}}
-        
+
     conn = get_conn()
     conn.delete_index_if_exists("test-pindex")
     conn.create_index("test-pindex")
-    conn.put_mapping("test-type", {'properties':mapping}, ["test-pindex"])
-    conn.index({"name":"Joe Tester", "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":1, "doubles":[1.0, 2.0, 3.0]}, "test-pindex", "test-type", 1)
-    conn.index({"name":"Bill Baloney", "parsedtext":"Joe Testere nice guy", "uuid":"22222", "position":2, "doubles":[0.1, 0.2, 0.3]}, "test-pindex", "test-type", 2)
+    conn.put_mapping("test-type", {'properties': mapping}, ["test-pindex"])
+    conn.index({"name": "Joe Tester",
+                "parsedtext": "Joe Testere nice guy",
+                "uuid": "11111",
+                "position": 1,
+                "doubles": [1.0, 2.0, 3.0]}, "test-pindex", "test-type", 1)
+    conn.index({"name": "Bill Baloney",
+                "parsedtext": "Joe Testere nice guy",
+                "uuid": "22222",
+                "position": 2,
+                "doubles": [0.1, 0.2, 0.3]}, "test-pindex", "test-type", 2)
     conn.refresh(["test-pindex"])
+
 
 def tearDown():
     """Remove the package level index.

--- a/pyes/tests/pyestest.py
+++ b/pyes/tests/pyestest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 
 import unittest
@@ -9,8 +10,10 @@ from pyes import ES
 from pprint import pprint
 from pyes.helpers import SettingsBuilder
 
+
 def get_conn(*args, **kwargs):
     return ES('127.0.0.1:9200', *args, **kwargs)
+
 
 class ESTestCase(unittest.TestCase):
 
@@ -48,29 +51,29 @@ class ESTestCase(unittest.TestCase):
 
     def init_default_index(self):
         settings = SettingsBuilder()
-        settings.add_mapping({self.document_type:{'properties':
-                { u'parsedtext': {'boost': 1.0,
+        properties = {u'parsedtext': {'boost': 1.0,
+                                      'index': 'analyzed',
+                                      'store': 'yes',
+                                      'type': u'string',
+                                      "term_vector": "with_positions_offsets"},
+                      u'name': {'boost': 1.0,
+                                'index': 'analyzed',
+                                'store': 'yes',
+                                'type': u'string',
+                                "term_vector": "with_positions_offsets"},
+                      u'title': {'boost': 1.0,
                                  'index': 'analyzed',
                                  'store': 'yes',
                                  'type': u'string',
-                                 "term_vector" : "with_positions_offsets"},
-                         u'name': {'boost': 1.0,
-                                    'index': 'analyzed',
-                                    'store': 'yes',
-                                    'type': u'string',
-                                    "term_vector" : "with_positions_offsets"},
-                         u'title': {'boost': 1.0,
-                                    'index': 'analyzed',
-                                    'store': 'yes',
-                                    'type': u'string',
-                                    "term_vector" : "with_positions_offsets"},
-                         u'pos': {'store': 'yes',
-                                    'type': u'integer'},
-                         u'uuid': {'boost': 1.0,
-                                   'index': 'not_analyzed',
-                                   'store': 'yes',
-                                   'type': u'string'}}
-                          }}, name=self.document_type)
+                                 "term_vector": "with_positions_offsets"},
+                      u'pos': {'store': 'yes',
+                               'type': u'integer'},
+                      u'uuid': {'boost': 1.0,
+                                'index': 'not_analyzed',
+                                'store': 'yes',
+                                'type': u'string'}}
+        mapping = {self.document_type: {'properties': properties}}
+        settings.add_mapping(mapping, name=self.document_type)
 
         self.conn.create_index(self.index_name, settings)
 

--- a/pyes/tests/test_aliases.py
+++ b/pyes/tests/test_aliases.py
@@ -7,6 +7,7 @@ import unittest
 from pyes.tests import ESTestCase
 import pyes.exceptions
 
+
 class ErrorReportingTestCase(ESTestCase):
     def setUp(self):
         super(ErrorReportingTestCase, self).setUp()
@@ -58,7 +59,8 @@ class ErrorReportingTestCase(ESTestCase):
         self.assertTrue('test-index' in result)
         self.assertEqual(result['test-index'], {'num_docs': 0})
         self.assertTrue('test-alias' in result)
-        self.assertEqual(result['test-alias'], {'alias_for': ['test-index'], 'num_docs': 0})
+        self.assertEqual(result['test-alias'],
+                         {'alias_for': ['test-index'], 'num_docs': 0})
 
         result = self.conn.get_indices(include_aliases=False)
         self.assertTrue('test-index' in result)
@@ -87,8 +89,11 @@ class ErrorReportingTestCase(ESTestCase):
     def testWriteToAlias(self):
         self.assertTrue('ok' in self.conn.create_index(self.index_name))
         self.assertTrue('ok' in self.conn.create_index("test-index2"))
-        self.assertTrue('ok' in self.conn.set_alias("test-alias", ['test-index']))
-        self.assertTrue('ok' in self.conn.set_alias("test-alias2", ['test-index', 'test-index2']))
+        self.assertTrue('ok' in self.conn.set_alias("test-alias",
+                                                    ['test-index']))
+        self.assertTrue('ok' in self.conn.set_alias("test-alias2",
+                                                    ['test-index',
+                                                     'test-index2']))
 
         # Can write to aliases only if they point to exactly one index.
         self.conn.index(dict(title='doc1'), 'test-index', 'testtype')
@@ -98,13 +103,16 @@ class ErrorReportingTestCase(ESTestCase):
                          self.conn.index, dict(title='doc1'),
                          'test-alias2', 'testtype')
 
-        self.conn.refresh() # ensure that the documents have been indexed.
+        self.conn.refresh()  # ensure that the documents have been indexed.
         # Check the document counts for each index or alias.
         result = self.conn.get_indices(include_aliases=True)
         self.assertEqual(result['test-index'], {'num_docs': 2})
         self.assertEqual(result['test-index2'], {'num_docs': 1})
-        self.assertEqual(result['test-alias'], {'alias_for': ['test-index'], 'num_docs': 2})
-        self.assertEqual(result['test-alias2'], {'alias_for': ['test-index', 'test-index2'], 'num_docs': 3})
+        self.assertEqual(result['test-alias'],
+                         {'alias_for': ['test-index'], 'num_docs': 2})
+        self.assertEqual(result['test-alias2'],
+                         {'alias_for': ['test-index', 'test-index2'],
+                          'num_docs': 3})
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyes/tests/test_attachments.py
+++ b/pyes/tests/test_attachments.py
@@ -1,25 +1,25 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import os
 from pyestest import ESTestCase
 from pyes import TermQuery, file_to_attachment
 
+
 class TestFileSaveTestCase(ESTestCase):
     def test_filesave(self):
-        mapping = {
-                   "my_attachment" : { "type" : "attachment",
-                                      'fields':{
-                                        "file" : {'store' : "yes"},
-                                        "date" : {'store' : "yes"},
-                                        "author" : {'store': "yes"},
-                                        "title" : {'store': "yes"}, }
-                                      }
-                   }
+        mapping = {"my_attachment": {"type": "attachment",
+                                     'fields': {"file": {'store': "yes"},
+                                                "date": {'store': "yes"},
+                                                "author": {'store': "yes"},
+                                                "title": {'store': "yes"}}}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {self.document_type:{'properties':mapping}}, self.index_name)
+        self.conn.put_mapping(self.document_type,
+                              {self.document_type: {'properties': mapping}},
+                              self.index_name)
         self.conn.refresh(self.index_name)
         self.conn.get_mapping(self.document_type, self.index_name)
         name = "__init__.py"
@@ -27,58 +27,46 @@ class TestFileSaveTestCase(ESTestCase):
         self.conn.put_file(name, self.index_name, self.document_type, 1)
         self.conn.refresh(self.index_name)
         _ = self.conn.get_mapping(self.document_type, self.index_name)
-        nname, ncontent = self.conn.get_file(self.index_name, self.document_type, 1)
+        nname, ncontent = self.conn.get_file(self.index_name,
+                                             self.document_type, 1)
         self.assertEquals(name, nname)
         self.assertEquals(content, ncontent)
+
 
 class QueryAttachmentTestCase(ESTestCase):
     def setUp(self):
         super(QueryAttachmentTestCase, self).setUp()
-        mapping = {
-                   "attachment" : { "type" : "attachment",
-                                      'fields':{
-                                        "file" : {'store' : "yes"},
-                                        "date" : {'store' : "yes"},
-                                        "author" : {'store': "yes"},
-                                        "title" : {'store': "yes", "term_vector" : "with_positions_offsets"},
-                                        "attachment" : {'store': "yes"},
-                                        }
-                                      },
+        fields = {"file": {'store': "yes"},
+                  "date": {'store': "yes"},
+                  "author": {'store': "yes"},
+                  "title": {'store': "yes",
+                            "term_vector": "with_positions_offsets"},
+                  "attachment": {'store': "yes"}}
+        mapping = {"attachment": {"type": "attachment",
+                                  'fields': fields},
                    'uuid': {'boost': 1.0,
                            'index': 'not_analyzed',
                            'store': 'yes',
-                           'type': u'string'}
-                   }
-#        mapping = {
-#            self.document_type: {
-#                "_index": {"enabled": "yes"},
-#                "_id": {"store": "yes"},
-#                "properties": {
-#                    "attachment": {
-#                        "type": "attachment",
-#                        "fields": {
-#                            "title": {"store": "yes", "term_vector" : "with_positions_offsets"},
-#                            "attachment": {"store":"yes", "term_vector" : "with_positions_offsets"}
-#                        },
-#                        "store":"yes"
-#                        
-#                    },
-#                    "uuid": {"type": "string", "store": "yes", "index": "not_analyzed"}
-#                },
-#                "_all": {"store": "yes", "term_vector": "with_positions_offsets"}
-#            }
-#        }
+                           'type': u'string'}}
         self.conn.debug_dump = True
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {self.document_type:{'properties':mapping}}, self.index_name)
+        self.conn.put_mapping(self.document_type,
+                              {self.document_type: {'properties': mapping}},
+                              self.index_name)
         self.conn.refresh(self.index_name)
         self.conn.get_mapping(self.document_type, self.index_name)
-        self.conn.index({"attachment":file_to_attachment(os.path.join("data", "testXHTML.html")), "uuid":"1" }, self.index_name, self.document_type, 1)
+        attachment = file_to_attachment(os.path.join("data",
+                                                     "testXHTML.html"))
+        self.conn.index({"attachment": attachment, "uuid": "1"},
+                        self.index_name, self.document_type, 1)
         self.conn.refresh(self.index_name)
 
     def test_TermQuery(self):
-        q = TermQuery("uuid", "1").search(fields=['attachment', 'attachment.author', 'attachment.title', 'attachment.date'])
-#        q = TermQuery("uuid", "1", fields=['*'])
+        q = TermQuery("uuid", "1").search(fields=['attachment',
+                                                  'attachment.author',
+                                                  'attachment.title',
+                                                  'attachment.date'])
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 1)
-        self.assertEquals(resultset.hits[0]['fields']['attachment.author'], u'Tika Developers')
+        self.assertEquals(resultset.hits[0]['fields']['attachment.author'],
+                          u'Tika Developers')

--- a/pyes/tests/test_bulk.py
+++ b/pyes/tests/test_bulk.py
@@ -1,42 +1,57 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase
 from pyes import TermQuery
 
+
 class BulkTestCase(ESTestCase):
     def setUp(self):
         super(BulkTestCase, self).setUp()
-        mapping = { u'parsedtext': {'boost': 1.0,
-                         'index': 'analyzed',
-                         'store': 'yes',
-                         'type': u'string',
-                         "term_vector" : "with_positions_offsets"},
-                 u'name': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'title': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'pos': {'store': 'yes',
+        mapping = {u'parsedtext': {'boost': 1.0,
+                                   'index': 'analyzed',
+                                   'store': 'yes',
+                                   'type': u'string',
+                                   "term_vector": "with_positions_offsets"},
+                   u'name': {'boost': 1.0,
+                             'index': 'analyzed',
+                             'store': 'yes',
+                             'type': u'string',
+                             "term_vector": "with_positions_offsets"},
+                   u'title': {'boost': 1.0,
+                              'index': 'analyzed',
+                              'store': 'yes',
+                              'type': u'string',
+                              "term_vector": "with_positions_offsets"},
+                   u'pos': {'store': 'yes',
                             'type': u'integer'},
-                 u'uuid': {'boost': 1.0,
-                           'index': 'not_analyzed',
-                           'store': 'yes',
-                           'type': u'string'}}
+                   u'uuid': {'boost': 1.0,
+                             'index': 'not_analyzed',
+                             'store': 'yes',
+                             'type': u'string'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
-        self.conn.index({"name":"Joe Tester", "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":1}, self.index_name, self.document_type, 1, bulk=True)
-        self.conn.index({"name":"Bill Baloney", "parsedtext":"Bill Testere nice guy", "uuid":"22222", "position":2}, self.index_name, self.document_type, 2, bulk=True)
-        self.conn.index({"name":"Bill Clinton", "parsedtext":"""Bill is not 
-                nice guy""", "uuid":"33333", "position":3}, self.index_name, self.document_type, 3, bulk=True)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
+        self.conn.index({"name": "Joe Tester",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "11111",
+                         "position": 1},
+                         self.index_name, self.document_type, 1, bulk=True)
+        self.conn.index({"name": "Bill Baloney",
+                         "parsedtext": "Bill Testere nice guy",
+                         "uuid": "22222",
+                         "position": 2},
+                         self.index_name, self.document_type, 2, bulk=True)
+        self.conn.index({"name": "Bill Clinton",
+                         "parsedtext": """Bill is not
+                                          nice guy""",
+                         "uuid": "33333",
+                         "position": 3},
+                         self.index_name, self.document_type, 3, bulk=True)
         bulk_result = self.conn.force_bulk()
         self.assertEquals(len(bulk_result['items']), 3)
         self.conn.refresh(self.index_name)
@@ -45,6 +60,7 @@ class BulkTestCase(ESTestCase):
         q = TermQuery("name", "bill")
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyes/tests/test_cluster.py
+++ b/pyes/tests/test_cluster.py
@@ -1,41 +1,56 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase
 
+
 class ClusterTestCase(ESTestCase):
     def setUp(self):
         super(ClusterTestCase, self).setUp()
-        mapping = { u'parsedtext': {'boost': 1.0,
-                         'index': 'analyzed',
-                         'store': 'yes',
-                         'type': u'string',
-                         "term_vector" : "with_positions_offsets"},
-                 u'name': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'title': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'pos': {'store': 'yes',
+        mapping = {u'parsedtext': {'boost': 1.0,
+                                   'index': 'analyzed',
+                                   'store': 'yes',
+                                   'type': u'string',
+                                   "term_vector": "with_positions_offsets"},
+                   u'name': {'boost': 1.0,
+                             'index': 'analyzed',
+                             'store': 'yes',
+                             'type': u'string',
+                             "term_vector": "with_positions_offsets"},
+                   u'title': {'boost': 1.0,
+                              'index': 'analyzed',
+                              'store': 'yes',
+                              'type': u'string',
+                              "term_vector": "with_positions_offsets"},
+                   u'pos': {'store': 'yes',
                             'type': u'integer'},
-                 u'uuid': {'boost': 1.0,
-                           'index': 'not_analyzed',
-                           'store': 'yes',
-                           'type': u'string'}}
+                   u'uuid': {'boost': 1.0,
+                             'index': 'not_analyzed',
+                             'store': 'yes',
+                             'type': u'string'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
-        self.conn.index({"name":"Joe Tester", "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":1}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"Bill Baloney", "parsedtext":"Bill Testere nice guy", "uuid":"22222", "position":2}, self.index_name, self.document_type, 2)
-        self.conn.index({"name":"Bill Clinton", "parsedtext":"""Bill is not 
-                nice guy""", "uuid":"33333", "position":3}, self.index_name, self.document_type, 3)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
+        self.conn.index({"name": "Joe Tester",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "11111",
+                         "position": 1},
+                         self.index_name, self.document_type, 1)
+        self.conn.index({"name": "Bill Baloney",
+                         "parsedtext": "Bill Testere nice guy",
+                         "uuid": "22222",
+                         "position": 2},
+                         self.index_name, self.document_type, 2)
+        self.conn.index({"name": "Bill Clinton",
+                         "parsedtext": """Bill is not
+                                          nice guy""",
+                         "uuid": "33333",
+                         "position": 3},
+                         self.index_name, self.document_type, 3)
         self.conn.refresh(self.index_name)
 
     def test_ClusterState(self):

--- a/pyes/tests/test_convert_errors.py
+++ b/pyes/tests/test_convert_errors.py
@@ -28,10 +28,11 @@ class RaiseIfErrorTestCase(ESTestCase):
             IndexAlreadyExistsException,
             convert_errors.raise_if_error,
             400, {u'status': 400,
-                  u'error': (u'RemoteTransportException[[name][inet' +
-                             u'[/127.0.0.1:9300]][indices/createIndex]]; ' +
-                             u'nested: IndexAlreadyExistsException['+
+                  u'error': (u'RemoteTransportException[[name][inet'
+                             u'[/127.0.0.1:9300]][indices/createIndex]]; '
+                             u'nested: IndexAlreadyExistsException['
                              u'[test-index] Already exists]; ')})
-        
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyes/tests/test_dump_curl.py
+++ b/pyes/tests/test_dump_curl.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase, get_conn
 import StringIO
+
 
 class DumpCurlTestCase(ESTestCase):
     def setUp(self):
@@ -17,13 +19,15 @@ class DumpCurlTestCase(ESTestCase):
         """
         dump = StringIO.StringIO()
         conn = get_conn(dump_curl=dump)
-        result = conn.index(dict(title="Hi"), self.index_name, self.document_type)
+        result = conn.index(dict(title="Hi"), self.index_name,
+                            self.document_type)
         self.assertTrue('ok' in result)
         self.assertTrue('error' not in result)
 
         dump = dump.getvalue()
-        self.assertTrue('test-index/test-type -d \"{\\"title\\": \\"Hi\\"}\"\n'
-                        in dump)
+        value = 'test-index/test-type -d \"{\\"title\\": \\"Hi\\"}\"\n'
+        self.assertTrue(value in dump)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyes/tests/test_errors.py
+++ b/pyes/tests/test_errors.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase
 import pyes.exceptions
+
 
 class ErrorReportingTestCase(ESTestCase):
     def setUp(self):
@@ -58,9 +60,11 @@ class ErrorReportingTestCase(ESTestCase):
         """
         err = self.checkRaises(pyes.exceptions.ElasticSearchException,
                                self.conn._send_request, 'GET', '_bad_request')
-        self.assertEqual(str(err), "No handler found for uri [/_bad_request] and method [GET]")
+        err_msg = "No handler found for uri [/_bad_request] and method [GET]"
+        self.assertEqual(str(err), err_msg)
+
         self.assertEqual(err.status, 400)
-        self.assertEqual(err.result, 'No handler found for uri [/_bad_request] and method [GET]')
+        self.assertEqual(err.result, err_msg)
 
     def testDelete(self):
         """Test error reported by deleting a missing document.

--- a/pyes/tests/test_esmodel.py
+++ b/pyes/tests/test_esmodel.py
@@ -9,8 +9,10 @@ from pyes.es import DotDict
 from copy import deepcopy
 
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
+
 
 class ElasticSearchModelTestCase(ESTestCase):
     def setUp(self):
@@ -18,7 +20,8 @@ class ElasticSearchModelTestCase(ESTestCase):
         self.init_default_index()
 
     def test_ElasticSearchModel_init(self):
-        obj = self.conn.factory_object(self.index_name, self.document_type, {"name":"test", "val":1})
+        obj = self.conn.factory_object(self.index_name, self.document_type,
+                                       {"name": "test", "val": 1})
         self.assertEqual(obj.name, "test")
         obj.name = "aaa"
         self.assertEqual(obj.name, "aaa")
@@ -31,7 +34,8 @@ class ElasticSearchModelTestCase(ESTestCase):
         obj.name = "test2"
         obj.save()
 
-        reloaded = self.conn.get(self.index_name, self.document_type, obj.meta.id)
+        reloaded = self.conn.get(self.index_name, self.document_type,
+                                 obj.meta.id)
         self.assertEqual(reloaded.name, "test2")
 
     def test_DotDict(self):
@@ -48,6 +52,7 @@ class ElasticSearchModelTestCase(ESTestCase):
         self.assertEqual(dotdict["bar"]["baz"], "qux")
         self.assertEqual(dotdict2["bar"]["baz"], "foo")
         self.assertEqual(type(dotdict2), DotDict)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyes/tests/test_facets.py
+++ b/pyes/tests/test_facets.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin and the lang-javascript plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin and the
+lang-javascript plugin running on the default port (localhost:9500).
 """
 from pyestest import ESTestCase
 from pyes.facets import DateHistogramFacet
@@ -12,36 +13,38 @@ import unittest
 
 import datetime
 
+
 class FacetSearchTestCase(ESTestCase):
     def setUp(self):
         super(FacetSearchTestCase, self).setUp()
-        mapping = { u'parsedtext': {'boost': 1.0,
-                         'index': 'analyzed',
-                         'store': 'yes',
-                         'type': u'string',
-                         "term_vector" : "with_positions_offsets"},
-                 u'name': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'title': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'position': {'store': 'yes',
-                               'type': u'integer'},
-                 u'tag': {'store': 'yes',
-                          'type': u'string'},
-                 u'date': {'store': 'yes',
-                           'type': u'date'},
-                 u'uuid': {'boost': 1.0,
-                           'index': 'not_analyzed',
-                           'store': 'yes',
-                           'type': u'string'}}
+        mapping = {u'parsedtext': {'boost': 1.0,
+                                   'index': 'analyzed',
+                                   'store': 'yes',
+                                   'type': u'string',
+                                   "term_vector": "with_positions_offsets"},
+                   u'name': {'boost': 1.0,
+                             'index': 'analyzed',
+                             'store': 'yes',
+                             'type': u'string',
+                             "term_vector": "with_positions_offsets"},
+                   u'title': {'boost': 1.0,
+                              'index': 'analyzed',
+                              'store': 'yes',
+                              'type': u'string',
+                              "term_vector": "with_positions_offsets"},
+                   u'position': {'store': 'yes',
+                                 'type': u'integer'},
+                   u'tag': {'store': 'yes',
+                            'type': u'string'},
+                   u'date': {'store': 'yes',
+                             'type': u'date'},
+                   u'uuid': {'boost': 1.0,
+                             'index': 'not_analyzed',
+                             'store': 'yes',
+                             'type': u'string'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
         self.conn.index({"name": "Joe Tester",
                          "parsedtext": "Joe Testere nice guy",
                          "uuid": "11111",
@@ -49,7 +52,7 @@ class FacetSearchTestCase(ESTestCase):
                          "tag": "foo",
                          "date": datetime.date(2011, 5, 16)},
                         self.index_name, self.document_type, 1)
-        self.conn.index({"name":" Bill Baloney",
+        self.conn.index({"name": "Bill Baloney",
                          "parsedtext": "Bill Testere nice guy",
                          "uuid": "22222",
                          "position": 2,
@@ -69,10 +72,12 @@ class FacetSearchTestCase(ESTestCase):
         q = MatchAllQuery()
         q = q.search()
         q.facet.add_term_facet('tag')
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 3)
-        self.assertEquals(resultset.facets.tag.terms, [{u'count': 2, u'term': u'foo'},
-                                                             {u'count': 1, u'term': u'bar'}])
+        self.assertEquals(resultset.facets.tag.terms,
+                          [{u'count': 2, u'term': u'foo'},
+                           {u'count': 1, u'term': u'bar'}])
 
         q2 = MatchAllQuery()
         q2 = q2.search()
@@ -92,10 +97,13 @@ class FacetSearchTestCase(ESTestCase):
         q = FilteredQuery(q, TermFilter('tag', 'foo'))
         q = q.search()
         q.facet.add_term_facet('tag')
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 2)
-        self.assertEquals(resultset.facets['tag']['terms'], [{u'count': 2, u'term': u'foo'}])
-        self.assertEquals(resultset.facets.tag.terms, [{u'count': 2, u'term': u'foo'}])
+        self.assertEquals(resultset.facets['tag']['terms'],
+                          [{u'count': 2, u'term': u'foo'}])
+        self.assertEquals(resultset.facets.tag.terms,
+                          [{u'count': 2, u'term': u'foo'}])
 
         q2 = MatchAllQuery()
         q2 = FilteredQuery(q2, TermFilter('tag', 'foo'))
@@ -119,28 +127,35 @@ class FacetSearchTestCase(ESTestCase):
         q.facet.facets.append(DateHistogramFacet('date_facet',
                                                  field='date',
                                                  interval='month'))
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 3)
-        self.assertEquals(resultset.facets.date_facet.entries, [{u'count': 2, u'time': 1301616000000},
-                                                                      {u'count': 1, u'time': 1304208000000}])
-        self.assertEquals(datetime.datetime.fromtimestamp(1301616000000 / 1000.).date(),
-                          datetime.date(2011, 04, 01))
-        self.assertEquals(datetime.datetime.fromtimestamp(1304208000000 / 1000.).date(),
-                          datetime.date(2011, 05, 01))
+        self.assertEquals(resultset.facets.date_facet.entries,
+                          [{u'count': 2, u'time': 1301616000000},
+                           {u'count': 1, u'time': 1304208000000}])
+        d1 = datetime.datetime.fromtimestamp(1301616000000 / 1000.).date()
+        d2 = datetime.datetime.fromtimestamp(1304208000000 / 1000.).date()
+        self.assertEquals(d1, datetime.date(2011, 04, 01))
+        self.assertEquals(d2, datetime.date(2011, 05, 01))
 
     def test_date_facet_filter(self):
         q = MatchAllQuery()
-        q = FilteredQuery(q, RangeFilter(qrange=ESRange('date',
-                                                        datetime.date(2011, 4, 1),
-                                                        datetime.date(2011, 5, 1),
-                                                        include_upper=False)))
+        range = ESRange('date',
+                        datetime.date(2011, 4, 1),
+                        datetime.date(2011, 5, 1),
+                        include_upper=False)
+
+        q = FilteredQuery(q, RangeFilter(qrange=range))
         q = q.search()
         q.facet.facets.append(DateHistogramFacet('date_facet',
                                                  field='date',
                                                  interval='month'))
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 2)
-        self.assertEquals(resultset.facets['date_facet']['entries'], [{u'count': 2, u'time': 1301616000000}])
+        self.assertEquals(resultset.facets['date_facet']['entries'],
+                          [{u'count': 2, u'time': 1301616000000}])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyes/tests/test_geoloc.py
+++ b/pyes/tests/test_geoloc.py
@@ -1,53 +1,37 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase
-from pyes import GeoBoundingBoxFilter, GeoDistanceFilter, GeoPolygonFilter, FilteredQuery, MatchAllQuery
+from pyes import GeoBoundingBoxFilter, GeoDistanceFilter, GeoPolygonFilter
+from pyes import FilteredQuery, MatchAllQuery
+
 
 #--- Geo Queries Test case
 class GeoQuerySearchTestCase(ESTestCase):
 
     def setUp(self):
         super(GeoQuerySearchTestCase, self).setUp()
-        mapping = {
-            "pin" : {
-                "properties" : {
-                    "location" : {
-                        "type" : "geo_point"
-                    }
-                }
-            }
-        }
+        mapping = {"pin": {"properties": {"location": {"type": "geo_point"}}}}
         self.conn.delete_index_if_exists("test-mindex")
         self.conn.create_index("test-mindex")
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, ["test-mindex"])
-        self.conn.index({
-            "pin" : {
-                "location" : {
-                    "lat" : 40.12,
-                    "lon" :-71.34
-                }
-            }
-        }, "test-mindex", self.document_type, 1)
-        self.conn.index({
-            "pin" : {
-                "location" : {
-                    "lat" : 40.12,
-                    "lon" : 71.34
-                }
-            }
-        }, "test-mindex", self.document_type, 2)
-
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              ["test-mindex"])
+        self.conn.index({"pin": {"location": {"lat": 40.12, "lon": -71.34}}},
+                        "test-mindex", self.document_type, 1)
+        self.conn.index({"pin": {"location": {"lat": 40.12, "lon": 71.34}}},
+                         "test-mindex", self.document_type, 2)
         self.conn.refresh(["test-mindex"])
 
     def tearDown(self):
         self.conn.delete_index_if_exists("test-mindex")
 
     def test_GeoDistanceFilter(self):
-        gq = GeoDistanceFilter("pin.location", {"lat" : 40, "lon" :70}, "200km")
+        gq = GeoDistanceFilter("pin.location", {"lat": 40,
+                                                "lon": 70}, "200km")
         q = FilteredQuery(MatchAllQuery(), gq)
         resultset = self.conn.search(query=q, indices=["test-mindex"])
         self.assertEquals(resultset.total, 1)
@@ -58,12 +42,15 @@ class GeoQuerySearchTestCase(ESTestCase):
         self.assertEquals(resultset.total, 1)
 
     def test_GeoBoundingBoxFilter(self):
-        gq = GeoBoundingBoxFilter("pin.location", location_tl={"lat" : 40.717, "lon" : 70.99}, location_br={"lat" : 40.03, "lon" : 72.0})
+        gq = GeoBoundingBoxFilter("pin.location",
+                                  location_tl={"lat": 40.717, "lon": 70.99},
+                                  location_br={"lat": 40.03, "lon": 72.0})
         q = FilteredQuery(MatchAllQuery(), gq)
         resultset = self.conn.search(query=q, indices=["test-mindex"])
         self.assertEquals(resultset.total, 1)
 
-        gq = GeoBoundingBoxFilter("pin.location", [70.99, 40.717], [74.1, 40.03])
+        gq = GeoBoundingBoxFilter("pin.location", [70.99, 40.717],
+                                  [74.1, 40.03])
         q = FilteredQuery(MatchAllQuery(), gq)
         result2 = self.conn.search(query=q, indices=["test-mindex"])
         self.assertEquals(result2.total, 1)
@@ -72,21 +59,20 @@ class GeoQuerySearchTestCase(ESTestCase):
 #        self.assertEquals(result, result2)
 
     def test_GeoPolygonFilter(self):
-        gq = GeoPolygonFilter("pin.location", [{"lat" : 50, "lon" :-30},
-                                                {"lat" : 30, "lon" :-80},
-                                                {"lat" : 80, "lon" :-90}]
-                                                )
+        gq = GeoPolygonFilter("pin.location", [{"lat": 50, "lon": -30},
+                                                {"lat": 30, "lon": -80},
+                                                {"lat": 80, "lon": -90}])
         q = FilteredQuery(MatchAllQuery(), gq)
         resultset = self.conn.search(query=q, indices=["test-mindex"])
         self.assertEquals(resultset.total, 1)
 
-        gq = GeoPolygonFilter("pin.location", [[ -30, 50],
-                                              [ -80, 30],
-                                              [ -90, 80]]
-                                                )
+        gq = GeoPolygonFilter("pin.location", [[-30, 50],
+                                               [-80, 30],
+                                               [-90, 80]])
         q = FilteredQuery(MatchAllQuery(), gq)
         resultset = self.conn.search(query=q, indices=["test-mindex"])
         self.assertEquals(resultset.total, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyes/tests/test_highlight.py
+++ b/pyes/tests/test_highlight.py
@@ -1,41 +1,55 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase
 from pyes import Search, StringQuery, HighLighter
 
+
 class QuerySearchTestCase(ESTestCase):
     def setUp(self):
         super(QuerySearchTestCase, self).setUp()
-        mapping = { u'parsedtext': {'boost': 1.0,
-                         'index': 'analyzed',
-                         'store': 'yes',
-                         'type': u'string',
-                         "term_vector" : "with_positions_offsets"},
-                 u'name': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'title': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'pos': {'store': 'yes',
+        mapping = {u'parsedtext': {'boost': 1.0,
+                                   'index': 'analyzed',
+                                   'store': 'yes',
+                                   'type': u'string',
+                                   "term_vector": "with_positions_offsets"},
+                   u'name': {'boost': 1.0,
+                             'index': 'analyzed',
+                             'store': 'yes',
+                             'type': u'string',
+                             "term_vector": "with_positions_offsets"},
+                   u'title': {'boost': 1.0,
+                              'index': 'analyzed',
+                              'store': 'yes',
+                              'type': u'string',
+                              "term_vector": "with_positions_offsets"},
+                   u'pos': {'store': 'yes',
                             'type': u'integer'},
-                 u'uuid': {'boost': 1.0,
-                           'index': 'not_analyzed',
-                           'store': 'yes',
-                           'type': u'string'}}
+                   u'uuid': {'boost': 1.0,
+                             'index': 'not_analyzed',
+                             'store': 'yes',
+                             'type': u'string'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
-        self.conn.index({"name":"Joe Tester", "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":1}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"Bill Baloney", "parsedtext":"Joe Testere nice guy", "uuid":"22222", "position":2}, self.index_name, self.document_type, 2)
-        self.conn.index({"parsedtext":"Joe Testere nice guy", "uuid":"22222", "position":2}, self.index_name, self.document_type, 2)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
+        self.conn.index({"name": "Joe Tester",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "11111",
+                         "position": 1},
+                         self.index_name, self.document_type, 1)
+        self.conn.index({"name": "Bill Baloney",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "22222",
+                         "position": 2},
+                         self.index_name, self.document_type, 2)
+        self.conn.index({"parsedtext": "Joe Testere nice guy",
+                         "uuid": "22222",
+                         "position": 2},
+                         self.index_name, self.document_type, 2)
         self.conn.refresh(self.index_name)
 
     def test_QueryHighlight(self):

--- a/pyes/tests/test_indexing.py
+++ b/pyes/tests/test_indexing.py
@@ -1,13 +1,15 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase
 from pyes import TermQuery
-from pyes.exceptions import IndexAlreadyExistsException
+from pyes import exceptions
 from time import sleep
+
 
 class IndexingTestCase(ESTestCase):
     def setUp(self):
@@ -32,23 +34,30 @@ class IndexingTestCase(ESTestCase):
         Testing collecting server info
         """
         result = self.conn.collect_info()
-        self.assertTrue(result.has_key('server'))
-        self.assertTrue(result['server'].has_key('name'))
-        self.assertTrue(result['server'].has_key('version'))
+        self.assertTrue('server' in result)
+        self.assertTrue('name' in result['server'])
+        self.assertTrue('version' in result['server'])
 
     def testIndexingWithID(self):
         """
         Testing an indexing given an ID
         """
-        result = self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type, 1)
-        self.assertResultContains(result, {'_type': 'test-type', '_id': '1', 'ok': True, '_index': 'test-index'})
+        result = self.conn.index({"name": "Joe Tester"}, self.index_name,
+                                 self.document_type, 1)
+        self.assertResultContains(result, {'_type': 'test-type',
+                                           '_id': '1',
+                                           'ok': True,
+                                           '_index': 'test-index'})
 
     def testIndexingWithoutID(self):
         """Testing an indexing given without ID"""
-        result = self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type)
-        self.assertResultContains(result, {'_type': 'test-type', 'ok': True, '_index': 'test-index'})
+        result = self.conn.index({"name": "Joe Tester"}, self.index_name,
+                                 self.document_type)
+        self.assertResultContains(result, {'_type': 'test-type',
+                                           'ok': True,
+                                           '_index': 'test-index'})
         # should have an id of some value assigned.
-        self.assertTrue(result.has_key('_id') and result['_id'])
+        self.assertTrue('_id' in result and result['_id'])
 
     def testExplicitIndexCreate(self):
         """Creazione indice"""
@@ -57,16 +66,25 @@ class IndexingTestCase(ESTestCase):
         self.assertResultContains(result, {'acknowledged': True, 'ok': True})
 
     def testDeleteByID(self):
-        self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type, 1)
+        self.conn.index({"name": "Joe Tester"}, self.index_name,
+                        self.document_type, 1)
         self.conn.refresh(self.index_name)
         result = self.conn.delete(self.index_name, self.document_type, 1)
-        self.assertResultContains(result, {'_type': 'test-type', '_id': '1', 'ok': True, '_index': 'test-index'})
+        self.assertResultContains(result, {'_type': 'test-type',
+                                           '_id': '1',
+                                           'ok': True,
+                                           '_index': 'test-index'})
 
     def testDeleteByIDWithEncoding(self):
-        self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type, "http://hello/?#'there")
+        self.conn.index({"name": "Joe Tester"}, self.index_name,
+                        self.document_type, "http://hello/?#'there")
         self.conn.refresh(self.index_name)
-        result = self.conn.delete(self.index_name, self.document_type, "http://hello/?#'there")
-        self.assertResultContains(result, {'_type': 'test-type', '_id': 'http://hello/?#\'there', 'ok': True, '_index': 'test-index'})
+        result = self.conn.delete(self.index_name, self.document_type,
+                                  "http://hello/?#'there")
+        self.assertResultContains(result, {'_type': 'test-type',
+                                           '_id': 'http://hello/?#\'there',
+                                           'ok': True,
+                                           '_index': 'test-index'})
 
     def testDeleteIndex(self):
         self.conn.create_index("another-index")
@@ -75,18 +93,23 @@ class IndexingTestCase(ESTestCase):
 
     def testCannotCreateExistingIndex(self):
         self.conn.create_index("another-index")
-        self.assertRaises(IndexAlreadyExistsException, self.conn.create_index, "another-index")
+        self.assertRaises(exceptions.IndexAlreadyExistsException,
+                          self.conn.create_index, "another-index")
         self.conn.delete_index("another-index")
 
     def testPutMapping(self):
-        result = self.conn.put_mapping(self.document_type, {self.document_type : {"properties" : {"name" : {"type" : "string", "store" : "yes"}}}}, indices=self.index_name)
+        doc_type = self.document_type
+        mapping = {doc_type: {"properties": {"name": {"type": "string",
+                                                      "store": "yes"}}}}
+        result = self.conn.put_mapping(self.document_type, mapping,
+                                       indices=self.index_name)
         self.assertResultContains(result, {'acknowledged': True, 'ok': True})
 
     def testIndexStatus(self):
         self.conn.create_index("another-index")
         result = self.conn.status(["another-index"])
         self.conn.delete_index("another-index")
-        self.assertTrue(result.has_key('indices'))
+        self.assertTrue('indices' in result)
         self.assertResultContains(result, {'ok': True})
 
     def testIndexFlush(self):
@@ -107,74 +130,144 @@ class IndexingTestCase(ESTestCase):
         self.conn.delete_index("another-index")
         self.assertResultContains(result, {'ok': True})
 
-
     def testGetByID(self):
-        self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"Bill Baloney"}, self.index_name, self.document_type, 2)
+        self.conn.index({"name": "Joe Tester"}, self.index_name,
+                        self.document_type, 1)
+        self.conn.index({"name": "Bill Baloney"}, self.index_name,
+                        self.document_type, 2)
         self.conn.refresh(self.index_name)
         result = self.conn.get(self.index_name, self.document_type, 1)
-        self.assertResultContains(result, {'_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index'})
+        self.assertResultContains(result, {'_type': 'test-type',
+                                           '_id': '1',
+                                           '_source': {'name': 'Joe Tester'},
+                                           '_index': 'test-index'})
 
     def testMultiGet(self):
-        self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"Bill Baloney"}, self.index_name, self.document_type, 2)
+        self.conn.index({"name": "Joe Tester"}, self.index_name,
+                        self.document_type, 1)
+        self.conn.index({"name": "Bill Baloney"}, self.index_name,
+                        self.document_type, 2)
         self.conn.refresh(self.index_name)
-        results = self.conn.mget(["1", "2"], self.index_name, self.document_type)
+        results = self.conn.mget(["1", "2"], self.index_name,
+                                 self.document_type)
         self.assertEqual(len(results), 2)
 
     def testGetCountBySearch(self):
-        self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"Bill Baloney"}, self.index_name, self.document_type, 2)
+        self.conn.index({"name": "Joe Tester"}, self.index_name,
+                        self.document_type, 1)
+        self.conn.index({"name": "Bill Baloney"}, self.index_name,
+                        self.document_type, 2)
         self.conn.refresh(self.index_name)
         q = TermQuery("name", "joe")
         result = self.conn.count(q, indices=self.index_name)
         self.assertResultContains(result, {'count': 1})
 
-
 #    def testSearchByField(self):
 #        resultset = self.conn.search("name:joe")
-#        self.assertResultContains(result, {'hits': {'hits': [{'_type': 'test-type', '_id': '1', '_source': {'name': 'Joe Tester'}, '_index': 'test-index'}], 'total': 1}})
+#        hits = {'hits': {'hits': [{'_type': 'test-type',
+#                                   '_id': '1',
+#                                   '_source': {'name': 'Joe Tester'},
+#                                   '_index': 'test-index'}],
+#                         'total': 1}})
+#        self.assertResultContains(result, hits)
 
 #    def testTermsByField(self):
 #        result = self.conn.terms(['name'])
-#        self.assertResultContains(result, {'docs': {'max_doc': 2, 'num_docs': 2, 'deleted_docs': 0}, 'fields': {'name': {'terms': [{'term': 'baloney', 'doc_freq': 1}, {'term': 'bill', 'doc_freq': 1}, {'term': 'joe', 'doc_freq': 1}, {'term': 'tester', 'doc_freq': 1}]}}})
-#        
+#        docs = {'docs': {'max_doc': 2,
+#                         'num_docs': 2,
+#                         'deleted_docs': 0},
+#                'fields': {'name': {'terms': [{'term': 'baloney',
+#                                               'doc_freq': 1},
+#                                              {'term': 'bill',
+#                                               'doc_freq': 1},
+#                                              {'term': 'joe',
+#                                               'doc_freq': 1},
+#                                              {'term': 'tester',
+#                                               'doc_freq': 1}]}}})
+#        self.assertResultContains(result, docs)
+
 #    def testTermsByIndex(self):
 #        result = self.conn.terms(['name'], indices=['test-index'])
-#        self.assertResultContains(result, {'docs': {'max_doc': 2, 'num_docs': 2, 'deleted_docs': 0}, 'fields': {'name': {'terms': [{'term': 'baloney', 'doc_freq': 1}, {'term': 'bill', 'doc_freq': 1}, {'term': 'joe', 'doc_freq': 1}, {'term': 'tester', 'doc_freq': 1}]}}})
-#
+#        docs = {'docs': {'max_doc': 2,
+#                         'num_docs': 2,
+#                         'deleted_docs': 0},
+#                'fields': {'name': {'terms': [{'term': 'baloney',
+#                                               'doc_freq': 1},
+#                                              {'term': 'bill',
+#                                               'doc_freq': 1},
+#                                              {'term': 'joe',
+#                                               'doc_freq': 1},
+#                                              {'term': 'tester',
+#                                               'doc_freq': 1}]}}})
+#        self.assertResultContains(result, docs)
+
 #    def testTermsMinFreq(self):
 #        result = self.conn.terms(['name'], min_freq=2)
-#        self.assertResultContains(result, {'docs': {'max_doc': 2, 'num_docs': 2, 'deleted_docs': 0}, 'fields': {'name': {'terms': []}}})
+#        docs = {'docs': {'max_doc': 2,
+#                         'num_docs': 2,
+#                         'deleted_docs': 0},
+#                'fields': {'name': {'terms': []}}})
+#        self.assertResultContains(result, docs)
 
     def testMLT(self):
-        self.conn.index({"name":"Joe Test"}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"Joe Tester"}, self.index_name, self.document_type, 2)
-        self.conn.index({"name":"Joe Tested"}, self.index_name, self.document_type, 3)
+        self.conn.index({"name": "Joe Test"}, self.index_name,
+                        self.document_type, 1)
+        self.conn.index({"name": "Joe Tester"}, self.index_name,
+                        self.document_type, 2)
+        self.conn.index({"name": "Joe Tested"}, self.index_name,
+                        self.document_type, 3)
         self.conn.refresh(self.index_name)
         sleep(0.5)
-        result = self.conn.morelikethis(self.index_name, self.document_type, 1, ['name'], min_term_freq=1, min_doc_freq=1)
+        result = self.conn.morelikethis(self.index_name, self.document_type,
+                                        1, ['name'], min_term_freq=1,
+                                        min_doc_freq=1)
         del result[u'took']
-        self.assertResultContains(result, {u'_shards': {u'successful': 5, u'failed': 0, u'total': 5}})
+        self.assertResultContains(result,
+                                  {u'_shards': {u'successful': 5,
+                                                u'failed': 0,
+                                                u'total': 5}})
         self.assertTrue(u'hits' in result)
-        self.assertResultContains(result['hits'], {u'hits': [
-                                  {u'_score': 0.19178301, u'_type': u'test-type', u'_id': u'3', u'_source': {u'name': u'Joe Tested'}, u'_index': u'test-index', u'_version': 1},
-                                  {u'_score': 0.19178301, u'_type': u'test-type', u'_id': u'2', u'_source': {u'name': u'Joe Tester'}, u'_index': u'test-index', u'_version': 1}
-                                  ], u'total': 2, u'max_score': 0.19178301})
+        hits = {u'hits': [{u'_score': 0.19178301,
+                           u'_type': u'test-type',
+                           u'_id': u'3',
+                           u'_source': {u'name': u'Joe Tested'},
+                           u'_index': u'test-index',
+                           u'_version': 1},
+                          {u'_score': 0.19178301,
+                           u'_type': u'test-type',
+                           u'_id': u'2',
+                           u'_source': {u'name': u'Joe Tester'},
+                           u'_index': u'test-index',
+                           u'_version': 1}],
+                u'total': 2,
+                u'max_score': 0.19178301}
+        self.assertResultContains(result['hits'], hits)
 
     def testVersion(self):
-        self.conn.index({"name":"Joe Test"}, self.index_name, self.document_type, 1, force_insert=True)
-        self.assertRaises(DocumentAlreadyExistsEngineException,
+        self.conn.index({"name": "Joe Test"}, self.index_name,
+                        self.document_type, 1, force_insert=True)
+        self.assertRaises(exceptions.DocumentAlreadyExistsEngineException,
                           self.conn.index,
-                          *({"name":"Joe Test2"}, self.index_name, self.document_type, 1), **{"force_insert":True})
-        self.conn.index({"name":"Joe Test"}, self.index_name, self.document_type, 1, version=1)
-        self.conn.index({"name":"Joe Test"}, self.index_name, self.document_type, 1, version=2)
-        self.assertRaises(VersionConflictEngineException,
+                          *({"name": "Joe Test2"},
+                            self.index_name,
+                            self.document_type,
+                            1),
+                          **{"force_insert": True})
+        self.conn.index({"name": "Joe Test"}, self.index_name,
+                        self.document_type, 1, version=1)
+        self.conn.index({"name": "Joe Test"}, self.index_name,
+                        self.document_type, 1, version=2)
+        self.assertRaises(exceptions.VersionConflictEngineException,
                           self.conn.index,
-                          *({"name":"Joe Test2"}, self.index_name, self.document_type, 1), **{"version":2})
+                          *({"name": "Joe Test2"},
+                            self.index_name,
+                            self.document_type,
+                            1),
+                          **{"version": 2})
         item = self.conn.get(self.index_name, self.document_type, 1)
         self.assertEqual(item["_version"], 3)
         self.assertEqual(item._version, 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyes/tests/test_mapping_parser.py
+++ b/pyes/tests/test_mapping_parser.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase
@@ -9,10 +10,12 @@ from pyes import decode_json
 from pyes.mappings import Mapper
 import os
 
+
 class MapperTestCase(ESTestCase):
     def setUp(self):
         super(MapperTestCase, self).setUp()
-        self.datamap = decode_json(open(os.path.join("data", "map.json"), "rb").read())
+        self.datamap = decode_json(open(os.path.join("data", "map.json"),
+                                        "rb").read())
 
     def test_parser(self):
         _ = Mapper(self.datamap)

--- a/pyes/tests/test_multifield.py
+++ b/pyes/tests/test_multifield.py
@@ -1,111 +1,73 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyes.tests import ESTestCase
 from pyes import TermQuery
 from datetime import datetime
 
+
 class MultifieldTestCase(ESTestCase):
     def setUp(self):
         super(MultifieldTestCase, self).setUp()
-        mapping = { u'parsedtext': {'boost': 1.0,
-                         'index': 'analyzed',
-                         'store': 'yes',
-                         'type': u'string',
-                         "term_vector" : "with_positions_offsets"},
-                 u'title': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                u'name': {"type" : "multi_field",
-                                  "fields":{
-                                     u'name':{
-                                        u'boost': 1.0,
-                                         u'index': u'analyzed',
-                                         u'omit_norms': False,
-                                         u'omit_term_freq_and_positions': False,
-                                         u'store': u'yes',
-                                         "term_vector" : "with_positions_offsets",
-                                         u'type': u'string'},
-                                     u'untouched':{u'boost': 1.0,
-                                         u'index': u'not_analyzed',
-                                         u'omit_norms': False,
-                                         u'omit_term_freq_and_positions': False,
-                                         u'store': u'yes',
-                                         "term_vector" : "no",
-                                         u'type': u'string'}
-
-                                        }
-
-                 },
-#                u'value': {"type" : "multi_field",
-#                                  "fields":{
-#                                     u'string':{
-#                                        u'boost': 1.0,
-#                                         u'index': u'analyzed',
-#                                         u'omit_norms': False,
-#                                         u'omit_term_freq_and_positions': False,
-#                                         u'store': u'yes',
-#                                         "term_vector" : "with_positions_offsets",
-#                                         u'type': u'string'},
-#                                     u'ustring':{u'boost': 1.0,
-#                                         u'index': u'not_analyzed',
-#                                         u'omit_norms': False,
-#                                         u'omit_term_freq_and_positions': False,
-#                                         u'store': u'yes',
-#                                         "term_vector" : "no",
-#                                         u'type': u'string'},
-#                                     u'long':{u'boost': 1.0,
-#                                         u'index': u'not_analyzed',
-#                                         u'omit_norms': False,
-#                                         u'omit_term_freq_and_positions': False,
-#                                         u'store': u'yes',
-#                                         "term_vector" : "no",
-#                                         u'type': u'long'},
-#                                     u'date':{u'boost': 1.0,
-#                                         u'index': u'not_analyzed',
-#                                         u'omit_norms': False,
-#                                         u'omit_term_freq_and_positions': False,
-#                                         u'store': u'yes',
-#                                         "term_vector" : "no",
-#                                         u'type': u'date'},
-#                                     u'bool':{u'boost': 1.0,
-#                                         u'index': u'not_analyzed',
-#                                         u'omit_norms': False,
-#                                         u'omit_term_freq_and_positions': False,
-#                                         u'store': u'yes',
-#                                         "term_vector" : "no",
-#                                         u'type': u'boolean'},
-#                                     u'double':{u'boost': 1.0,
-#                                         u'index': u'not_analyzed',
-#                                         u'omit_norms': False,
-#                                         u'omit_term_freq_and_positions': False,
-#                                         u'store': u'yes',
-#                                         "term_vector" : "no",
-#                                         u'type': u'double'}
-#
-#                                        }
-#
-#                 },
-                 u'pos': {'store': 'yes',
+        fields = {u'name': {u'boost': 1.0,
+                            u'index': u'analyzed',
+                            u'omit_norms': False,
+                            u'omit_term_freq_and_positions': False,
+                            u'store': u'yes',
+                            "term_vector": "with_positions_offsets",
+                            u'type': u'string'},
+                  u'untouched': {u'boost': 1.0,
+                                 u'index': u'not_analyzed',
+                                 u'omit_norms': False,
+                                 u'omit_term_freq_and_positions': False,
+                                 u'store': u'yes',
+                                 "term_vector": "no",
+                                 u'type': u'string'}}
+        mapping = {u'parsedtext': {'boost': 1.0,
+                                   'index': 'analyzed',
+                                   'store': 'yes',
+                                   'type': u'string',
+                                   "term_vector": "with_positions_offsets"},
+                   u'title': {'boost': 1.0,
+                              'index': 'analyzed',
+                              'store': 'yes',
+                              'type': u'string',
+                              "term_vector": "with_positions_offsets"},
+                   u'name': {"type": "multi_field",
+                             "fields": fields},
+                   u'pos': {'store': 'yes',
                             'type': u'integer'},
-                 u'uuid': {'boost': 1.0,
-                           'index': 'not_analyzed',
-                           'store': 'yes',
-                           'type': u'string'}}
+                   u'uuid': {'boost': 1.0,
+                             'index': 'not_analyzed',
+                             'store': 'yes',
+                             'type': u'string'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
-        self.conn.index({"name":"Joe Tester", "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":1}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"Bill Baloney", "parsedtext":"Joe Testere nice guy", "uuid":"22222", "position":2}, self.index_name, self.document_type, 2)
-        self.conn.index({"value":"Joe Tester"}, self.index_name, self.document_type)
-        self.conn.index({"value":123343543536}, self.index_name, self.document_type)
-        self.conn.index({"value":True}, self.index_name, self.document_type)
-        self.conn.index({"value":43.32}, self.index_name, self.document_type)
-        self.conn.index({"value":datetime.now()}, self.index_name, self.document_type)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
+        self.conn.index({"name": "Joe Tester",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "11111",
+                         "position": 1},
+                         self.index_name, self.document_type, 1)
+        self.conn.index({"name": "Bill Baloney",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "22222",
+                         "position": 2},
+                         self.index_name, self.document_type, 2)
+        self.conn.index({"value": "Joe Tester"}, self.index_name,
+                        self.document_type)
+        self.conn.index({"value": 123343543536}, self.index_name,
+                        self.document_type)
+        self.conn.index({"value": True}, self.index_name,
+                        self.document_type)
+        self.conn.index({"value": 43.32}, self.index_name,
+                        self.document_type)
+        self.conn.index({"value": datetime.now()}, self.index_name,
+                        self.document_type)
         self.conn.refresh(self.index_name)
 
     def test_TermQuery(self):

--- a/pyes/tests/test_nested.py
+++ b/pyes/tests/test_nested.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin and the lang-javascript plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin and the
+lang-javascript plugin running on the default port (localhost:9500).
 """
 from pyestest import ESTestCase
 from pyes.filters import TermFilter, NestedFilter
@@ -9,17 +10,15 @@ from pyes.query import FilteredQuery, MatchAllQuery, BoolQuery, TermQuery
 
 import unittest
 
+
 class NestedSearchTestCase(ESTestCase):
     def setUp(self):
         super(NestedSearchTestCase, self).setUp()
 
-        mapping = {
-            'nested1': {
-                'type': 'nested'
-            }
-        }
+        mapping = {'nested1': {'type': 'nested'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties': mapping}, self.index_name)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
         self.conn.index({"field1": "value1",
                          "nested1": [{"n_field1": "n_value1_1",
                                       "n_field2": "n_value2_1"},
@@ -37,33 +36,36 @@ class NestedSearchTestCase(ESTestCase):
     def test_nested_filter(self):
         q = FilteredQuery(MatchAllQuery(),
                           TermFilter('_all', 'n_value1_1'))
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 2)
 
         q = FilteredQuery(MatchAllQuery(),
                           TermFilter('nested1.n_field1', 'n_value1_1'))
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 0)
 
         q = FilteredQuery(MatchAllQuery(),
                           TermFilter('nested1.n_field1', 'n_value1_1'))
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 0)
 
-        q = FilteredQuery(MatchAllQuery(),
-                          NestedFilter('nested1',
-                                       BoolQuery(must=[TermQuery('nested1.n_field1', 'n_value1_1')])))
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        b = BoolQuery(must=[TermQuery('nested1.n_field1', 'n_value1_1')])
+        q = FilteredQuery(MatchAllQuery(), NestedFilter('nested1', b))
+
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 2)
 
-        q = FilteredQuery(MatchAllQuery(),
-                          NestedFilter('nested1',
-                                       BoolQuery(must=[TermQuery('nested1.n_field1', 'n_value1_1'),
-                                                       TermQuery('nested1.n_field2', 'n_value2_1')])))
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        b = BoolQuery(must=[TermQuery('nested1.n_field1', 'n_value1_1'),
+                            TermQuery('nested1.n_field2', 'n_value2_1')])
+        q = FilteredQuery(MatchAllQuery(), NestedFilter('nested1', b))
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 1)
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/pyes/tests/test_percolator.py
+++ b/pyes/tests/test_percolator.py
@@ -1,38 +1,41 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin and the lang-javascript plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin and the
+lang-javascript plugin running on the default port (localhost:9500).
 """
 from pyestest import ESTestCase
 from pyes.query import *
 import unittest
 
+
 class PercolatorTestCase(ESTestCase):
     def setUp(self):
         super(PercolatorTestCase, self).setUp()
-        mapping = { u'parsedtext': {'boost': 1.0,
-                         'index': 'analyzed',
-                         'store': 'yes',
-                         'type': u'string',
-                         "term_vector" : "with_positions_offsets"},
-                 u'name': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'title': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'pos': {'store': 'yes',
+        mapping = {u'parsedtext': {'boost': 1.0,
+                                   'index': 'analyzed',
+                                   'store': 'yes',
+                                   'type': u'string',
+                                   "term_vector": "with_positions_offsets"},
+                   u'name': {'boost': 1.0,
+                             'index': 'analyzed',
+                             'store': 'yes',
+                             'type': u'string',
+                             "term_vector": "with_positions_offsets"},
+                   u'title': {'boost': 1.0,
+                              'index': 'analyzed',
+                              'store': 'yes',
+                              'type': u'string',
+                              "term_vector": "with_positions_offsets"},
+                   u'pos': {'store': 'yes',
                             'type': u'integer'},
-                 u'uuid': {'boost': 1.0,
-                           'index': 'not_analyzed',
-                           'store': 'yes',
-                           'type': u'string'}}
+                   u'uuid': {'boost': 1.0,
+                             'index': 'not_analyzed',
+                             'store': 'yes',
+                             'type': u'string'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
         self.conn.create_percolator(
             'test-index',
             'test-perc1',
@@ -51,19 +54,22 @@ class PercolatorTestCase(ESTestCase):
         self.conn.refresh(self.index_name)
 
     def test_percolator(self):
-        results = self.conn.percolate('test-index', 'test-type', PercolatorQuery({'name': 'iphone'}))
+        results = self.conn.percolate('test-index', 'test-type',
+                                      PercolatorQuery({'name': 'iphone'}))
         self.assertTrue('test-perc1' not in results['matches'])
         self.assertTrue('test-perc2' in results['matches'])
         self.assertTrue('test-perc3' not in results['matches'])
 
     def test_or(self):
-        results = self.conn.percolate('test-index', 'test-type', PercolatorQuery({'name': 'apple'}))
+        results = self.conn.percolate('test-index', 'test-type',
+                                      PercolatorQuery({'name': 'apple'}))
         self.assertTrue('test-perc1' in results['matches'])
         self.assertTrue('test-perc2' in results['matches'])
         self.assertTrue('test-perc3' not in results['matches'])
 
     def test_and(self):
-        results = self.conn.percolate('test-index', 'test-type', PercolatorQuery({'name': 'apple iphone'}))
+        p = PercolatorQuery({'name': 'apple iphone'})
+        results = self.conn.percolate('test-index', 'test-type', p)
         self.assertTrue('test-perc1' in results['matches'])
         self.assertTrue('test-perc2' in results['matches'])
         self.assertTrue('test-perc3' in results['matches'])

--- a/pyes/tests/test_queries.py
+++ b/pyes/tests/test_queries.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin and the lang-javascript plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin and the
+lang-javascript plugin running on the default port (localhost:9500).
 """
 from pyestest import ESTestCase
 from pyes.query import *
@@ -9,39 +10,57 @@ from pyes.filters import TermFilter, ANDFilter, ORFilter, RangeFilter, RawFilter
 from pyes.utils import ESRangeOp
 import unittest
 
+
 class QuerySearchTestCase(ESTestCase):
     def setUp(self):
         super(QuerySearchTestCase, self).setUp()
-        mapping = { u'parsedtext': {'boost': 1.0,
-                         'index': 'analyzed',
-                         'store': 'yes',
-                         'type': u'string',
-                         "term_vector" : "with_positions_offsets"},
-                 u'name': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'title': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'pos': {'store': 'yes',
+        mapping = {u'parsedtext': {'boost': 1.0,
+                                   'index': 'analyzed',
+                                   'store': 'yes',
+                                   'type': u'string',
+                                   "term_vector": "with_positions_offsets"},
+                   u'name': {'boost': 1.0,
+                             'index': 'analyzed',
+                             'store': 'yes',
+                             'type': u'string',
+                             "term_vector": "with_positions_offsets"},
+                   u'title': {'boost': 1.0,
+                              'index': 'analyzed',
+                              'store': 'yes',
+                              'type': u'string',
+                              "term_vector": "with_positions_offsets"},
+                   u'pos': {'store': 'yes',
                             'type': u'integer'},
-                 u'uuid': {'boost': 1.0,
-                           'index': 'not_analyzed',
-                           'store': 'yes',
-                           'type': u'string'}}
+                   u'uuid': {'boost': 1.0,
+                             'index': 'not_analyzed',
+                             'store': 'yes',
+                             'type': u'string'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
-        self.conn.put_mapping("test-type2", {"_parent" : {"type" : self.document_type}}, self.index_name)
-        self.conn.index({"name":"Joe Tester", "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":1}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"data1", "value":"value1"}, self.index_name, "test-type2", 1, parent=1)
-        self.conn.index({"name":"Bill Baloney", "parsedtext":"Bill Testere nice guy", "uuid":"22222", "position":2}, self.index_name, self.document_type, 2)
-        self.conn.index({"name":"data2", "value":"value2"}, self.index_name, "test-type2", 2, parent=2)
-        self.conn.index({"name":"Bill Clinton", "parsedtext":"""Bill is not 
-                nice guy""", "uuid":"33333", "position":3}, self.index_name, self.document_type, 3)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
+        self.conn.put_mapping("test-type2",
+                              {"_parent": {"type": self.document_type}},
+                              self.index_name)
+        self.conn.index({"name": "Joe Tester",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "11111",
+                         "position": 1},
+                         self.index_name, self.document_type, 1)
+        self.conn.index({"name": "data1", "value": "value1"},
+                        self.index_name, "test-type2", 1, parent=1)
+        self.conn.index({"name": "Bill Baloney",
+                         "parsedtext": "Bill Testere nice guy",
+                         "uuid": "22222",
+                         "position": 2},
+                         self.index_name, self.document_type, 2)
+        self.conn.index({"name": "data2", "value": "value2"},
+                         self.index_name, "test-type2", 2, parent=2)
+        self.conn.index({"name": "Bill Clinton",
+                         "parsedtext": """Bill is not
+                                          nice guy""",
+                         "uuid": "33333",
+                         "position": 3},
+                         self.index_name, self.document_type, 3)
 
         self.conn.default_indices = self.index_name
 
@@ -106,7 +125,8 @@ class QuerySearchTestCase(ESTestCase):
 
     def test_MatchAllQuery(self):
         q = MatchAllQuery()
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 3)
         self.assertEquals(q, MatchAllQuery())
 
@@ -128,14 +148,18 @@ class QuerySearchTestCase(ESTestCase):
         q = BoolQuery(must=[q1, q2])
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 0)
-        self.assertEquals(q, BoolQuery(must=[StringQuery("joe"), StringQuery("test")]))
-        self.assertNotEquals(q, BoolQuery(must=[StringQuery("moe"), StringQuery("test")]))
+        self.assertEquals(q, BoolQuery(must=[StringQuery("joe"),
+                          StringQuery("test")]))
+        self.assertNotEquals(q, BoolQuery(must=[StringQuery("moe"),
+                             StringQuery("test")]))
 
         q = BoolQuery(should=[q1, q2])
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 1)
-        self.assertEquals(q, BoolQuery(should=[StringQuery("joe"), StringQuery("test")]))
-        self.assertNotEquals(q, BoolQuery(should=[StringQuery("moe"), StringQuery("test")]))
+        self.assertEquals(q, BoolQuery(should=[StringQuery("joe"),
+                          StringQuery("test")]))
+        self.assertNotEquals(q, BoolQuery(should=[StringQuery("moe"),
+                             StringQuery("test")]))
 
     def test_OR_AND_Filters(self):
         q1 = TermFilter("position", 1)
@@ -146,18 +170,22 @@ class QuerySearchTestCase(ESTestCase):
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 0)
         self.assertEquals(q, FilteredQuery(MatchAllQuery(),
-            ANDFilter([TermFilter("position", 1), TermFilter("position", 2)])))
+                          ANDFilter([TermFilter("position", 1),
+                                     TermFilter("position", 2)])))
         self.assertNotEquals(q, FilteredQuery(MatchAllQuery(),
-            ANDFilter([TermFilter("position", 1), TermFilter("position", 3)])))
+                             ANDFilter([TermFilter("position", 1),
+                                        TermFilter("position", 3)])))
 
         orq = ORFilter([q1, q2])
         q = FilteredQuery(MatchAllQuery(), orq)
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 2)
         self.assertEquals(q, FilteredQuery(MatchAllQuery(),
-            ORFilter([TermFilter("position", 1), TermFilter("position", 2)])))
+                          ORFilter([TermFilter("position", 1),
+                                    TermFilter("position", 2)])))
         self.assertNotEquals(q, FilteredQuery(MatchAllQuery(),
-            ORFilter([TermFilter("position", 1), TermFilter("position", 3)])))
+                             ORFilter([TermFilter("position", 1),
+                                       TermFilter("position", 3)])))
 
     def test_FieldQuery(self):
         q = FieldQuery(FieldParameter("name", "+joe"))
@@ -170,8 +198,12 @@ class QuerySearchTestCase(ESTestCase):
         q = DisMaxQuery(FieldQuery(FieldParameter("name", "+joe")))
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 1)
-        self.assertEquals(q, DisMaxQuery(FieldQuery(FieldParameter("name", "+joe"))))
-        self.assertNotEquals(q, DisMaxQuery(FieldQuery(FieldParameter("name", "+job"))))
+        self.assertEquals(q,
+                          DisMaxQuery(FieldQuery(FieldParameter("name",
+                                                                "+joe"))))
+        self.assertNotEquals(q,
+                             DisMaxQuery(FieldQuery(FieldParameter("name",
+                                                                   "+job"))))
 
     def test_FuzzyQuery(self):
         q = FuzzyQuery('name', 'data')
@@ -182,11 +214,14 @@ class QuerySearchTestCase(ESTestCase):
         self.assertNotEquals(q, FuzzyQuery('name', 'data2'))
 
     def test_HasChildQuery(self):
-        q = HasChildQuery(type="test-type2", query=TermQuery("name", "data1"))
+        q = HasChildQuery(type="test-type2", query=TermQuery("name",
+                                                             "data1"))
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 1)
-        self.assertEquals(q, HasChildQuery(type="test-type2", query=TermQuery("name", "data1")))
-        self.assertNotEquals(q, HasChildQuery(type="test-type2", query=TermQuery("name", "data2")))
+        self.assertEquals(q, HasChildQuery(type="test-type2",
+                          query=TermQuery("name", "data1")))
+        self.assertNotEquals(q, HasChildQuery(type="test-type2",
+                             query=TermQuery("name", "data2")))
 
     def test_RegexTermQuery(self):
         # Don't run this test, because it depends on the RegexTermQuery
@@ -196,7 +231,8 @@ class QuerySearchTestCase(ESTestCase):
         q = RegexTermQuery("name", "jo.")
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 1)
-        # When this test is re-enabled, be sure to add equality and inequality tests (issue 128)
+        # When this test is re-enabled, be sure to add equality and
+        # inequality tests (issue 128)
 
     def test_CustomScoreQueryMvel(self):
         q = CustomScoreQuery(query=MatchAllQuery(),
@@ -213,7 +249,8 @@ class QuerySearchTestCase(ESTestCase):
                              lang="mvel",
                              script="_score*(6+doc.position.value)"
                              ))
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 3)
         self.assertEquals(resultset[0].meta.score, 8.0)
         self.assertEquals(resultset[1].meta.score, 7.0)
@@ -224,7 +261,8 @@ class QuerySearchTestCase(ESTestCase):
                              lang="js",
                              script="parseFloat(_score*(5+doc.position.value))"
                              )
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 3)
         self.assertEquals(resultset[0].score, 8.0)
         self.assertEquals(resultset[1].score, 7.0)
@@ -235,7 +273,8 @@ class QuerySearchTestCase(ESTestCase):
                              lang="python",
                              script="parseFloat(_score*(5+doc.position.value))"
                              )
-        resultset = self.conn.search(query=q, indices=self.index_name, doc_types=[self.document_type])
+        resultset = self.conn.search(query=q, indices=self.index_name,
+                                     doc_types=[self.document_type])
         self.assertEquals(resultset.total, 3)
         self.assertEquals(resultset[0]._score, 8.0)
         self.assertEquals(resultset[1]._score, 7.0)
@@ -270,52 +309,56 @@ class QuerySearchTestCase(ESTestCase):
                           Search(filter=TermFilter("h", "ello")))
         self.assertNotEquals(Search(filter=TermFilter("h", "ello")),
                              Search(filter=TermFilter("j", "ello")))
-        self.assertEquals(Search(query=TermQuery("h", "ello"), filter=TermFilter("h", "ello")),
-                          Search(query=TermQuery("h", "ello"), filter=TermFilter("h", "ello")))
-        self.assertNotEquals(Search(query=TermQuery("h", "ello"), filter=TermFilter("h", "ello")),
-                             Search(query=TermQuery("j", "ello"), filter=TermFilter("j", "ello")))
-        
+        self.assertEquals(Search(query=TermQuery("h", "ello"),
+                                 filter=TermFilter("h", "ello")),
+                          Search(query=TermQuery("h", "ello"),
+                                 filter=TermFilter("h", "ello")))
+        self.assertNotEquals(Search(query=TermQuery("h", "ello"),
+                                    filter=TermFilter("h", "ello")),
+                             Search(query=TermQuery("j", "ello"),
+                                    filter=TermFilter("j", "ello")))
+
     def test_ESRange_equality(self):
         self.assertEquals(RangeQuery(),
-          RangeQuery())
+                          RangeQuery())
         self.assertEquals(RangeQuery(ESRange("foo", 1, 2)),
-          RangeQuery(ESRange("foo", 1, 2)))
+                          RangeQuery(ESRange("foo", 1, 2)))
         self.assertNotEquals(RangeQuery(ESRange("foo", 1, 2)),
-          RangeQuery(ESRange("bar", 1, 2)))
+                             RangeQuery(ESRange("bar", 1, 2)))
         self.assertEquals(RangeFilter(),
-          RangeFilter())
+                          RangeFilter())
         self.assertEquals(RangeFilter(ESRange("foo", 1, 2)),
-          RangeFilter(ESRange("foo", 1, 2)))
+                          RangeFilter(ESRange("foo", 1, 2)))
         self.assertNotEquals(RangeFilter(ESRange("foo", 1, 2)),
-          RangeFilter(ESRange("bar", 1, 2)))
+                             RangeFilter(ESRange("bar", 1, 2)))
         self.assertEquals(ESRange("foo"),
-          ESRange("foo"))
+                          ESRange("foo"))
         self.assertNotEquals(ESRange("foo"),
-          ESRange("bar"))
+                             ESRange("bar"))
         self.assertEquals(ESRange("foo", 1),
-          ESRange("foo", 1))
+                          ESRange("foo", 1))
         self.assertNotEquals(ESRange("foo", 1),
-          ESRange("foo", 2))
+                             ESRange("foo", 2))
         self.assertEquals(ESRange("foo", 1, 2),
-          ESRange("foo", 1, 2))
+                          ESRange("foo", 1, 2))
         self.assertNotEquals(ESRange("foo", 1, 2),
-          ESRange("foo", 1, 3))
+                             ESRange("foo", 1, 3))
         self.assertEquals(ESRange("foo", 1, 2, True, False),
-          ESRange("foo", 1, 2, True, False))
+                          ESRange("foo", 1, 2, True, False))
         self.assertNotEquals(ESRange("foo", 1, 2, True, False),
-          ESRange("foo", 1,2, False, True))
+                             ESRange("foo", 1, 2, False, True))
         self.assertEquals(ESRangeOp("foo", "gt", 5),
-          ESRangeOp("foo", "gt", 5))
+                          ESRangeOp("foo", "gt", 5))
         self.assertEquals(ESRangeOp("bar", "lt", 6),
-          ESRangeOp("bar", "lt", 6))
-        
+                          ESRangeOp("bar", "lt", 6))
+
     def test_RawFilter_dict(self):
         filter_ = dict(ids=dict(type="my_type", values=["1", "4", "100"]))
         self.assertEqual(RawFilter(filter_), RawFilter(filter_))
         self.assertEqual(RawFilter(filter_).serialize(), filter_)
         self.assertEqual(RawFilter(filter_).serialize(),
                          IdsFilter("my_type", ["1", "4", "100"]).serialize())
-  
+
     def test_RawFilter_string(self):
         filter_ = dict(ids=dict(type="my_type", values=["1", "4", "100"]))
         filter_string = json.dumps(filter_)
@@ -324,11 +367,11 @@ class QuerySearchTestCase(ESTestCase):
         self.assertEqual(RawFilter(filter_string).serialize(), filter_)
         self.assertEqual(RawFilter(filter_string).serialize(),
                          IdsFilter("my_type", ["1", "4", "100"]).serialize())
-          
+
     def test_RawFilter_search(self):
         filter_ = dict(ids=dict(type="my_type", values=["1", "4", "100"]))
         filter_string = json.dumps(filter_)
-    
+
         self.assertEqual(Search(filter=RawFilter(filter_)).serialize(),
           dict(filter=filter_))
         self.assertEqual(Search(filter=RawFilter(filter_string)).serialize(),

--- a/pyes/tests/test_resultset.py
+++ b/pyes/tests/test_resultset.py
@@ -8,8 +8,10 @@ from pyes.tests import ESTestCase
 from pyes.query import MatchAllQuery, Search
 
 """
-Unit tests for pyes  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
+
 
 class ResultsetTestCase(ESTestCase):
     def setUp(self):
@@ -17,15 +19,22 @@ class ResultsetTestCase(ESTestCase):
         self.init_default_index()
 
         for i in xrange(1000):
-                self.conn.index({"name":"Joe Tester%d" % i, "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":i}, self.index_name, self.document_type, i, bulk=True)
+            self.conn.index({"name": "Joe Tester%d" % i,
+                             "parsedtext": "Joe Testere nice guy",
+                             "uuid": "11111",
+                             "position": i},
+                             self.index_name,
+                             self.document_type,
+                             i,
+                             bulk=True)
         self.conn.refresh(self.index_name)
 
     def test_iterator(self):
-        resultset = self.conn.search(Search(MatchAllQuery(), size=10), self.index_name, self.document_type)
+        resultset = self.conn.search(Search(MatchAllQuery(), size=10),
+                                     self.index_name, self.document_type)
         self.assertEqual(len([p for p in resultset[:10]]), 10)
         self.assertEqual(resultset[10].uuid, "11111")
         self.assertEqual(resultset.total, 1000)
-
 
 
 if __name__ == "__main__":

--- a/pyes/tests/test_rivers.py
+++ b/pyes/tests/test_rivers.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
 import unittest
 from pyestest import ESTestCase
 from pyes.rivers import CouchDBRiver, RabbitMQRiver, TwitterRiver
+
 
 class RiversTestCase(ESTestCase):
     def setUp(self):
@@ -15,7 +17,8 @@ class RiversTestCase(ESTestCase):
         """
         Testing deleting a river
         """
-        test_river = CouchDBRiver(index_name='text_index', index_type='test_type')
+        test_river = CouchDBRiver(index_name='text_index',
+                                  index_type='test_type')
         result = self.conn.create_river(test_river, river_name='test_index')
         print result
         self.assertResultContains(result, {'ok': True})
@@ -24,7 +27,8 @@ class RiversTestCase(ESTestCase):
         """
         Testing deleting a river
         """
-        test_river = CouchDBRiver(index_name='text_index', index_type='test_type')
+        test_river = CouchDBRiver(index_name='text_index',
+                                  index_type='test_type')
         result = self.conn.delete_river(test_river, river_name='test_index')
         print result
         self.assertResultContains(result, {'ok': True})
@@ -33,7 +37,8 @@ class RiversTestCase(ESTestCase):
         """
         Testing deleting a river
         """
-        test_river = RabbitMQRiver(index_name='text_index', index_type='test_type')
+        test_river = RabbitMQRiver(index_name='text_index',
+                                   index_type='test_type')
         result = self.conn.create_river(test_river, river_name='test_index')
         print result
         self.assertResultContains(result, {'ok': True})
@@ -42,7 +47,8 @@ class RiversTestCase(ESTestCase):
         """
         Testing deleting a river
         """
-        test_river = RabbitMQRiver(index_name='text_index', index_type='test_type')
+        test_river = RabbitMQRiver(index_name='text_index',
+                                   index_type='test_type')
         result = self.conn.delete_river(test_river, river_name='test_index')
         print result
         self.assertResultContains(result, {'ok': True})
@@ -51,7 +57,8 @@ class RiversTestCase(ESTestCase):
         """
         Testing deleting a river
         """
-        test_river = TwitterRiver('test', 'test', index_name='text_index', index_type='test_type')
+        test_river = TwitterRiver('test', 'test', index_name='text_index',
+                                  index_type='test_type')
         result = self.conn.create_river(test_river, river_name='test_index')
         print result
         self.assertResultContains(result, {'ok': True})
@@ -60,11 +67,12 @@ class RiversTestCase(ESTestCase):
         """
         Testing deleting a river
         """
-        test_river = TwitterRiver('test', 'test', index_name='text_index', index_type='test_type')
+        test_river = TwitterRiver('test', 'test', index_name='text_index',
+                                  index_type='test_type')
         result = self.conn.delete_river(test_river, river_name='test_index')
         print result
         self.assertResultContains(result, {'ok': True})
 
+
 if __name__ == "__main__":
     unittest.main()
-

--- a/pyes/tests/test_scriptfields.py
+++ b/pyes/tests/test_scriptfields.py
@@ -8,6 +8,7 @@ import unittest
 import pyes.exceptions as exc
 import pyes.scriptfields as sf
 
+
 class ScriptFieldsTest(unittest.TestCase):
 
     def test_scriptfieldserror_imported(self):

--- a/pyes/tests/test_serialize.py
+++ b/pyes/tests/test_serialize.py
@@ -9,46 +9,60 @@ from pyes import TermQuery
 from datetime import datetime
 
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
+
 
 class SerializationTestCase(ESTestCase):
     def setUp(self):
         super(SerializationTestCase, self).setUp()
-        mapping = { u'parsedtext': {'boost': 1.0,
-                         'index': 'analyzed',
-                         'store': 'yes',
-                         'type': u'string',
-                         "term_vector" : "with_positions_offsets"},
-                 u'name': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'title': {'boost': 1.0,
-                            'index': 'analyzed',
-                            'store': 'yes',
-                            'type': u'string',
-                            "term_vector" : "with_positions_offsets"},
-                 u'pos': {'store': 'yes',
+        mapping = {u'parsedtext': {'boost': 1.0,
+                                   'index': 'analyzed',
+                                   'store': 'yes',
+                                   'type': u'string',
+                                   "term_vector": "with_positions_offsets"},
+                   u'name': {'boost': 1.0,
+                             'index': 'analyzed',
+                             'store': 'yes',
+                             'type': u'string',
+                             "term_vector": "with_positions_offsets"},
+                   u'title': {'boost': 1.0,
+                              'index': 'analyzed',
+                              'store': 'yes',
+                              'type': u'string',
+                              "term_vector": "with_positions_offsets"},
+                   u'pos': {'store': 'yes',
                             'type': u'integer'},
-                 u'inserted': {'store': 'yes',
-                            'type': u'date'},
-                 u'uuid': {'boost': 1.0,
-                           'index': 'not_analyzed',
-                           'store': 'yes',
-                           'type': u'string'}}
+                   u'inserted': {'store': 'yes',
+                                 'type': u'date'},
+                   u'uuid': {'boost': 1.0,
+                             'index': 'not_analyzed',
+                             'store': 'yes',
+                             'type': u'string'}}
         self.conn.create_index(self.index_name)
-        self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
-        self.conn.index({"name":"Joe Tester", "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":1, 'inserted':datetime(2010, 10, 22, 12, 12, 12)}, self.index_name, self.document_type, 1)
-        self.conn.index({"name":"Bill Baloney", "parsedtext":"Joe Testere nice guy", "uuid":"22222", "position":2, 'inserted':datetime(2010, 10, 22, 12, 12, 10)}, self.index_name, self.document_type, 2)
+        self.conn.put_mapping(self.document_type, {'properties': mapping},
+                              self.index_name)
+        self.conn.index({"name": "Joe Tester",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "11111",
+                         "position": 1,
+                         'inserted': datetime(2010, 10, 22, 12, 12, 12)},
+                         self.index_name, self.document_type, 1)
+        self.conn.index({"name": "Bill Baloney",
+                         "parsedtext": "Joe Testere nice guy",
+                         "uuid": "22222",
+                         "position": 2,
+                         'inserted': datetime(2010, 10, 22, 12, 12, 10)},
+                         self.index_name, self.document_type, 2)
         self.conn.refresh(self.index_name)
 
     def test_TermQuery(self):
         q = TermQuery("name", "joe")
         resultset = self.conn.search(query=q, indices=self.index_name)
         self.assertEquals(resultset.total, 1)
-        self.assertEquals(resultset.hits[0]['_source']['inserted'], datetime(2010, 10, 22, 12, 12, 12))
+        self.assertEquals(resultset.hits[0]['_source']['inserted'],
+                          datetime(2010, 10, 22, 12, 12, 12))
 
 
 if __name__ == "__main__":

--- a/pyes/tests/test_utils.py
+++ b/pyes/tests/test_utils.py
@@ -9,8 +9,10 @@ from pyes import TermQuery, clean_string
 from datetime import datetime
 
 """
-Unit tests for pyes.  These require an es server with thrift plugin running on the default port (localhost:9500).
+Unit tests for pyes.  These require an es server with thrift plugin running
+on the default port (localhost:9500).
 """
+
 
 class UtilsTestCase(ESTestCase):
 

--- a/pyes/utils.py
+++ b/pyes/utils.py
@@ -2,8 +2,10 @@
 # -*- coding: utf-8 -*-
 
 __author__ = 'Alberto Paro'
-__all__ = ['clean_string', "ESRange", "ESRangeOp", "string_b64encode", "string_b64decode"]
+__all__ = ['clean_string', "ESRange", "ESRangeOp", "string_b64encode",
+           "string_b64decode"]
 import base64
+
 
 def string_b64encode(s):
     """
@@ -12,15 +14,19 @@ def string_b64encode(s):
     """
     return base64.urlsafe_b64encode(s).strip('=')
 
+
 def string_b64decode(s):
     return base64.urlsafe_b64decode(s + '=' * (len(s) % 4))
+
 
 # Characters that are part of Lucene query syntax must be stripped
 # from user input: + - && || ! ( ) { } [ ] ^ " ~ * ? : \
 # See: http://lucene.apache.org/java/3_0_2/queryparsersyntax.html#Escaping
-SPECIAL_CHARS = [33, 34, 38, 40, 41, 42, 45, 58, 63, 91, 92, 93, 94, 123, 124, 125, 126]
+SPECIAL_CHARS = [33, 34, 38, 40, 41, 42, 45, 58, 63, 91, 92, 93, 94, 123,
+                 124, 125, 126]
 UNI_SPECIAL_CHARS = dict((c, None) for c in SPECIAL_CHARS)
 STR_SPECIAL_CHARS = ''.join([chr(c) for c in SPECIAL_CHARS])
+
 
 class EqualityComparableUsingAttributeDictionary(object):
     """
@@ -37,9 +43,11 @@ class EqualityComparableUsingAttributeDictionary(object):
     def __ne__(self, other):
         return not self == other
 
+
 class ESRange(EqualityComparableUsingAttributeDictionary):
-    def __init__(self, field, from_value=None, to_value=None, include_lower=None,
-                 include_upper=None, boost=None, **kwargs):
+    def __init__(self, field, from_value=None, to_value=None,
+                 include_lower=None, include_upper=None, boost=None,
+                 **kwargs):
         self.field = field
         self.from_value = from_value
         self.to_value = to_value
@@ -61,6 +69,7 @@ class ESRange(EqualityComparableUsingAttributeDictionary):
             filters['boost'] = self.boost
         return self.field, filters
 
+
 class ESRangeOp(ESRange):
     def __init__(self, field, op, value, boost=None):
         from_value = to_value = include_lower = include_upper = None
@@ -79,6 +88,7 @@ class ESRangeOp(ESRange):
         super(ESRangeOp, self).__init__(field, from_value, to_value,
                 include_lower, include_upper, boost)
 
+
 def clean_string(text):
     """
     Remove Lucene reserved characters from query string
@@ -86,6 +96,7 @@ def clean_string(text):
     if isinstance(text, unicode):
         return text.translate(UNI_SPECIAL_CHARS).strip()
     return text.translate(None, STR_SPECIAL_CHARS).strip()
+
 
 def keys_to_string(data):
     """


### PR DESCRIPTION
Previously python 2.6+ would always use the stdlib's json since the ImporError would never be thrown. It might be worth adding a dependency on anyjson since it provides a consistent api to the fastest json implementation installed.
