### PR TITLE
Add params to dump_curl() with pretty=true + uncommented 'operator' in TextQuery

### DIFF
--- a/pyes/query.py
+++ b/pyes/query.py
@@ -934,8 +934,8 @@ class TextQuery(Query):
             query["prefix_length"] = prefix_length
         if max_expansions != 2147483647:
             query["max_expansions"] = max_expansions
-#        if operator:
-#            query["operator"] = operator
+        if operator:
+            query["operator"] = operator
 
         self.queries[field] = query
 

--- a/pyes/tests/test_dump_curl.py
+++ b/pyes/tests/test_dump_curl.py
@@ -20,10 +20,10 @@ class DumpCurlTestCase(ESTestCase):
         result = conn.index(dict(title="Hi"), self.index_name, self.document_type)
         self.assertTrue('ok' in result)
         self.assertTrue('error' not in result)
-
         dump = dump.getvalue()
-        self.assertTrue('test-index/test-type -d \"{\\"title\\": \\"Hi\\"}\"\n'
-                        in dump)
+        self.assertTrue("""
+            curl -XPOST 'http://127.0.0.1:9200/test-index/test-type?pretty=true' -d '{"title": "Hi"}'
+            """.strip() in dump)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I had made independently a change very similar to https://github.com/aparo/pyes/pull/133, main addition is the "pretty=true". Also it uses stdlib functions for url fiddling instead of string concatenations.

A second unrelated commit is the uncommenting of 'operator' in TextQuery.
