### PR TITLE
Allow python 2.7 to use simplejson

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -7,11 +7,12 @@ __author__ = 'Alberto Paro'
 __all__ = ['ES', 'file_to_attachment', 'decode_json']
 
 try:
+    # For Python < 2.6 or people using a newer version of simplejson
+    import simplejson
+    json = simplejson
+except ImportError:
     # For Python >= 2.6
     import json
-except ImportError:
-    # For Python < 2.6 or people using a newer version of simplejson
-    import simplejson as json
 
 import logging
 from datetime import date, datetime

--- a/pyes/query.py
+++ b/pyes/query.py
@@ -6,11 +6,12 @@ __author__ = 'Alberto Paro'
 import logging
 
 try:
+    # For Python < 2.6 or people using a newer version of simplejson
+    import simplejson
+    json = simplejson
+except ImportError:
     # For Python >= 2.6
     import json
-except ImportError:
-    # For Python < 2.6 or people using a newer version of simplejson
-    import simplejson as json
 
 from es import ESJsonEncoder
 from utils import clean_string, ESRange, EqualityComparableUsingAttributeDictionary

--- a/pyes/rivers.py
+++ b/pyes/rivers.py
@@ -6,11 +6,12 @@ __author__ = 'Alberto Paro'
 import logging
 
 try:
+    # For Python < 2.6 or people using a newer version of simplejson
+    import simplejson
+    json = simplejson
+except ImportError:
     # For Python >= 2.6
     import json
-except ImportError:
-    # For Python < 2.6 or people using a newer version of simplejson
-    import simplejson as json
 
 from es import ESJsonEncoder
 


### PR DESCRIPTION
Previously python 2.6+ would always use the stdlib's json since the ImporError would never be thrown. It might be worth adding a dependency on anyjson since it provides a consistent api to the fastest json implementation installed.
