### PR TITLE
Improve thread-safety for bulk operations and add raise_on_bulk_item_failure which causes bulk operations to raise an exception on failure

### DIFF
--- a/pyes/exceptions.py
+++ b/pyes/exceptions.py
@@ -99,6 +99,7 @@ class DocumentAlreadyExistsEngineException(ElasticSearchException):
     pass
 
 class BulkOperationException(ElasticSearchException, EqualityComparableUsingAttributeDictionary):
-    def __init__(self, errors):
+    def __init__(self, errors, bulk_result):
       super(BulkOperationException, self).__init__(u"At least one operation in the bulk request has failed: %s" % errors)
       self.errors = errors
+      self.bulk_result = bulk_result


### PR DESCRIPTION
Because this is a bigger change, I'm sending it as a pull request for review instead of merging it in myself :-)

There is an interface change (added optional raise_on_bulk_item_failure with default False) but nothing breaking.

Do you think raise_on_bulk_item_failure should default to True? Setting it to False keeps the existing behavior but I think setting the default to True is safer: since clients probably aren't carefully checking the return value of a bulk operation, they may be silently losing index operations now.
