### PR TITLE
Fix Search.serialize() for the case where self.query is a dict

### DIFF
--- a/pyes/query.py
+++ b/pyes/query.py
@@ -132,6 +132,8 @@ class Search(EqualityComparableUsingAttributeDictionary):
         """
         res = {}
         if self.query:
+            if isinstance(self.query, dict):
+                return self.query
             res["query"] = self.query.serialize()
         if self.filter:
             res['filter'] = self.filter.serialize()


### PR DESCRIPTION
If a dictionary is passed as `query` to `search()` in es.py, a `ResultSet` object is created with the dict. This triggers the `if not isinstance(query, Search)` branch in the constructor, which creates a `Search` object with the dict. When this `Search` object is later serialized in `search_raw`, `Search.serialize()` will assume the dict is actually a `Query` object (I believe) when in fact it's a dict; an exception occurs. The traceback looks like this:

```
  File "C:\PYTHON27\lib\site-packages\pyes-0.17.0-py2.7.egg\pyes\es.py", line 1423, in next
    self._do_search()
  File "C:\PYTHON27\lib\site-packages\pyes-0.17.0-py2.7.egg\pyes\es.py", line 1294, in _do_search
    doc_types=self.doc_types, **self.query_params)
  File "C:\PYTHON27\lib\site-packages\pyes-0.17.0-py2.7.egg\pyes\es.py", line 1051, in search_raw
    body = query.to_search_json()
  File "C:\PYTHON27\lib\site-packages\pyes-0.17.0-py2.7.egg\pyes\query.py", line 200, in to_search_json
    return json.dumps(self.q, cls=ESJsonEncoder)
  File "C:\PYTHON27\lib\site-packages\pyes-0.17.0-py2.7.egg\pyes\query.py", line 125, in q
    return self.serialize()
  File "C:\PYTHON27\lib\site-packages\pyes-0.17.0-py2.7.egg\pyes\query.py", line 133, in serialize
    res["query"] = self.query.serialize()
AttributeError: 'dict' object has no attribute 'serialize'
```
