### PR TITLE
Handle datetimes before 1900

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -165,10 +165,10 @@ class ESJsonEncoder(json.JSONEncoder):
         """
 
         if isinstance(value, datetime):
-            return value.strftime("%Y-%m-%dT%H:%M:%S")
+            return value.isoformat()
         elif isinstance(value, date):
             dt = datetime(value.year, value.month, value.day, 0, 0, 0)
-            return dt.strftime("%Y-%m-%dT%H:%M:%S")
+            return dt.isoformat()
         elif isinstance(value, Decimal):
             return float(str(value))
         else:

--- a/pyes/tests/test_serialize.py
+++ b/pyes/tests/test_serialize.py
@@ -5,7 +5,8 @@ __author__ = 'Alberto Paro'
 
 import unittest
 from pyes.tests import ESTestCase
-from pyes import TermQuery
+from pyes import TermQuery, RangeQuery
+from pyes.utils import ESRange
 from datetime import datetime
 
 """
@@ -42,6 +43,7 @@ class SerializationTestCase(ESTestCase):
         self.conn.put_mapping(self.document_type, {'properties':mapping}, self.index_name)
         self.conn.index({"name":"Joe Tester", "parsedtext":"Joe Testere nice guy", "uuid":"11111", "position":1, 'inserted':datetime(2010, 10, 22, 12, 12, 12)}, self.index_name, self.document_type, 1)
         self.conn.index({"name":"Bill Baloney", "parsedtext":"Joe Testere nice guy", "uuid":"22222", "position":2, 'inserted':datetime(2010, 10, 22, 12, 12, 10)}, self.index_name, self.document_type, 2)
+        self.conn.index({"name":"Jesus H Christ", "parsedtext":"Bible guy", "uuid":"33333", "position":3, 'inserted':datetime(1, 1, 1, 0, 0, 0)}, self.index_name, self.document_type, 3)
         self.conn.refresh(self.index_name)
 
     def test_TermQuery(self):
@@ -50,6 +52,13 @@ class SerializationTestCase(ESTestCase):
         self.assertEquals(resultset.total, 1)
         hit = resultset[0]
         self.assertEquals(hit.inserted, datetime(2010, 10, 22, 12, 12, 12))
+
+    def test_DateBefore1900(self):
+        q = RangeQuery(ESRange("inserted", datetime(1, 1, 1), datetime(2, 1, 1)))
+        resultset = self.conn.search(query=q, indices=self.index_name)
+        self.assertEquals(resultset.total, 1)
+        hit = resultset[0]
+        self.assertEquals(hit.inserted, datetime(1, 1, 1, 0, 0, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Created a patch to fix an issue in the serializing:

> > > import pyes, datetime
> > > es = pyes.ES()
> > > es.index({'created': datetime.datetime(1863, 2, 1) }, 'test-index', 'test', '123')
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > >   File "/home/barnaby/git/pyes/pyes/es.py", line 990, in index
> > >     return self._send_request(request_method, path, doc, querystring_args)
> > >   File "/home/barnaby/git/pyes/pyes/es.py", line 405, in _send_request
> > >     body = json.dumps(body, cls=self.encoder)
> > >   File "/usr/lib/python2.7/dist-packages/simplejson/__init__.py", line 269, in dumps
> > >     use_decimal=use_decimal, **kw).encode(obj)
> > >   File "/usr/lib/python2.7/dist-packages/simplejson/encoder.py", line 216, in encode
> > >     chunks = self.iterencode(o, _one_shot=True)
> > >   File "/usr/lib/python2.7/dist-packages/simplejson/encoder.py", line 284, in iterencode
> > >     return _iterencode(o, 0)
> > >   File "/home/barnaby/git/pyes/pyes/es.py", line 168, in default
> > >     return value.strftime("%Y-%m-%dT%H:%M:%S")
> > > ValueError: year=1863 is before 1900; the datetime strftime() methods require year >= 1900
