### PR TITLE
Support params for analyze

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -873,12 +873,35 @@ class ES(object):
         result = self._send_request('POST', path, params=params)
         return result
 
-    def analyze(self, text, index=None):
+    def analyze(self, text, index=None, analyzer=None, tokenizer=None, filters=[], field=None):
         """
         Performs the analysis process on a text and return the tokens breakdown of the text
         """
+
+        argsets = 0
+        args = {}
+
+        if analyzer:
+            args['analyzer'] = analyzer
+            argsets += 1
+        if tokenizer or filters:
+            if tokenizer:
+                args['tokenizer'] = tokenizer
+            if filters:
+                args['filters'] = ','.join(filters)
+            argsets += 1
+        if field:
+            args['field'] = field
+            argsets += 1
+
+        if argsets > 1:
+            raise ValueError('Argument conflict: Speficy either analyzer, tokenizer/filters or field')
+
+        if field and index is None:
+            raise ValueError('field can only be specified with an index')
+
         path = self._make_path([index, '_analyze'])
-        return self._send_request('POST', path, text)
+        return self._send_request('POST', path, text, args)
 
     def gateway_snapshot(self, indices=None):
         """


### PR DESCRIPTION
Add support for the analyzer, tokenizer/filters and field parameters for the _analyze API.

This time with args passed directly to _send_request instead of urlencoding them to the path.
