### PR TITLE
Allow several couchdb rivers to be connected to the same ES index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 .*.swp
 docs/_build
+build/
+dist/
+pyes.egg-info/

--- a/pyes/es.py
+++ b/pyes/es.py
@@ -1322,7 +1322,7 @@ class ES(object):
         Create a river
         """
         if hasattr(river, "q"):
-            river_name = river.name
+            #river_name = river.name
             river = river.q
         return self._send_request('PUT', '/_river/%s/_meta' % river_name, river)
 

--- a/pyes/rivers.py
+++ b/pyes/rivers.py
@@ -20,6 +20,7 @@ log = logging.getLogger('pyes')
 class River(object):
     def __init__(self, index_name=None, index_type=None, bulk_size=100, bulk_timeout=None):
         self.name = index_name
+        self.name = None
         self.index_name = index_name
         self.index_type = index_type
         self.bulk_size = bulk_size


### PR DESCRIPTION
... a real problem here: the request uses the indexname instead of the river name

I am not sure how best to solve this problem. This hack is working for me. What I was trying to do was to have two different couchdb rivers connected to the same index. pyes is not doing that right.

What I want to do is what this gist does: https://gist.github.com/2429165

That is shell script, but I want to integrate that with my python environment, so I need pyes.
