### PR TITLE
Http connection leaking

### DIFF
--- a/pyes/connection_http.py
+++ b/pyes/connection_http.py
@@ -13,7 +13,7 @@ from . import logger
 __all__ = ['connect', 'connect_thread_local']
 
 DEFAULT_SERVER = ("http", "127.0.0.1", 9200)
-
+SESSION = requests.session()
 
 class ClientTransport(object):
     """Encapsulation of a client session."""
@@ -37,7 +37,7 @@ class ClientTransport(object):
         """Execute a request and return a response"""
         headers = self.headers.copy()
         headers.update(request.headers)
-        response = requests.session().request(
+        response = SESSION.request(
             method=Method._VALUES_TO_NAMES[request.method],
             url=self.server_uri + request.uri,
             params=request.parameters,


### PR DESCRIPTION
Since switching from urllib3 to requests (0262ea7037a60a8e7de00f1e3ab24218ef3383a4) pyes has been leaving hanging connections, which can eat up server resources real fast. The attached patch seems to solve the problem, although the underlying problem may actually be kennethreitz/requests#520.
