### PR TITLE
No longer ignore 'start' keyword when ES.search is called

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -1666,7 +1666,7 @@ class ResultSet(object):
             self.query = query
 
         self.iterpos = 0 #keep track of iterator position
-        self.start = self.query.start or 0
+        self.start = self.query.start or query_params.get("start", 0)
         self._max_item = self.query.size
         self._current_item = 0
         self.chuck_size = self.query.bulk_read or self.query.size or 10


### PR DESCRIPTION
Seems to be because the `start` field of the `ResultSet` object is always `None` when passed with a query object. (where query is _not_ of type Search)

When `ES.search` is passed with this keyword, `ResultSet` has this information as part of the `query_params` keyword argument. But this is ignored and not used.
