### PR TITLE
ES.cluster_health bug fix

### DIFF
--- a/pyes/tests/test_cluster.py
+++ b/pyes/tests/test_cluster.py
@@ -48,9 +48,23 @@ class ClusterTestCase(ESTestCase):
         self.assertTrue('nodes' in result)
 
     def test_ClusterHealth(self):
+        # Make sure that when we get the cluster health, that we get the
+        # default keys that we'd expect...
         result = self.conn.cluster_health()
-        print "health"
-        print result
+        for key in ['cluster_name', 'status', 'timed_out', 'number_of_nodes', 'number_of_data_nodes',
+            'active_primary_shards', 'active_shards', 'relocating_shards', 'initializing_shards', 'unassigned_shards']:
+            self.assertIn(key, result)
+        
+        # We should also make sure that at least /some/ of the keys are 
+        # the values that we'd expect
+        self.assertEqual(result['cluster_name'], 'elasticsearch')
+        # Make sure we see the number of active shards we expect
+        self.assertEqual(result['active_shards'], 24)
+        
+        # Now let's test that the indices bit actually works
+        result = self.conn.cluster_health(indices=['non-existent-index'], timeout=0, wait_for_status='green')
+        # There shouldn't be any active shards on this index
+        self.assertEqual(result['active_shards'], 0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added a unit test for cluster_health, and fixed cluster_health so that the
mappings args are provided as GET params (rather than the body), and added
support for indices.
