### PR TITLE
Add interval to histogram facet.

### DIFF
--- a/pyes/facets.py
+++ b/pyes/facets.py
@@ -130,6 +130,10 @@ class HistogramFacet(Facet):
                 raise RuntimeError("Invalid key_script: value_script required")
             if self.params:
                 data['params'] = self.params
+            if self.interval:
+                data['interval'] = self.interval
+            elif self.time_interval:
+                data['time_interval'] = self.time_interval
         params = self._base_parameters()
         params[self._internal_name]= data
         return {self.name: params}


### PR DESCRIPTION
Currently, if the histogram facet uses a key_script, pyes ignores
the interval completely. However elasticsearch has support for
intervals with key_scripts. This commit allows this functionality
to be used with pyes too.

This changeset does not break the pyes.tests.test_facets unittest.
