### PR TITLE
Don't collect info on creation of ES object

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -386,6 +386,7 @@ class ES(object):
         self.bulker_class = bulker_class
         self._raise_on_bulk_item_failure = raise_on_bulk_item_failure
 
+        self.info = {} #info about the current server
         if encoder:
             self.encoder = encoder
         if decoder:
@@ -402,7 +403,6 @@ class ES(object):
         self._check_servers()
         #init connections
         self._init_connection()
-        self.collect_info()
 
     def __del__(self):
         """


### PR DESCRIPTION
Keep the info as an empty dictionary instead and let the user call `collect_info` if necessary.

This behavior was recently introduced in https://github.com/aparo/pyes/commit/bd3ccf2af74d2f272f6b0921c5f57d654c7c5c5d. We have many indices and collecting the status of all them, as is done in `collect_info`, takes unnecessary time and bandwidth (the status response is ~1.5MB) when creating an `ES` object. This change allows the user to call `collect_info` if they desire that information, but does not force it to happen on creation.
