### PR TITLE
Show the query if there is a json.dumps exception

### DIFF
--- a/pyes/tests/test_errors.py
+++ b/pyes/tests/test_errors.py
@@ -67,6 +67,24 @@ class ErrorReportingTestCase(ESTestCase):
             self.conn.delete, self.index_name, "flibble",
             "asdf")
 
+    def testJsonErrors(self):
+
+        # Set up a circular reference error, which is common
+        # if you accidentally pass in a Django ORM object.
+        class _other:
+            prop = None
+        class _object:
+            prop = _other
+        _other.prop = _object
+
+        with self.assertRaises(ValueError) as cm:
+            self.conn.index({"name": _object,
+                             "parsedtext": "Joe Testere nice guy",
+                             "uuid": "11111", "position": 1},
+                            "errortest", None, 1)
+            assert '{"name": ' in cm.exception, (
+                                'Expected printed query: %s' % exc)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We've been hitting a circular reference error a lot when we build incorrect queries (accidentally) that contain objects that are unsafe for JSON. It's a real pain to track them down but as soon as we see the query it's pretty obvious what went wrong. This adds a well formatted query value to any json exceptions for faster debugging.