### PR TITLE
Replace requests with urllib3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,4 +17,4 @@ upload-dir = docs/.build/html
 [bdist_rpm]
 requires = python-thrift
            python-multiprocessing==2.6.2.1
-           requests==0.9.1
+           urllib3==1.4

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class QuickRunTests(TestCommand):
         TestCommand.run(self, *args, **kwargs)
 
 
-install_requires = ["requests"]
+install_requires = ["urllib3"]
 
 #if not sys.platform.startswith("java"):
 #    install_requires += [ "thrift", ]    


### PR DESCRIPTION
This patch brings back urllib3. Since it was replaced by requests earlier this year we had been experiencing almost daily a handful of timeouts and strange errors with corrupted json messages. Although it's been impossible to isolate and reproduce consistently the problem, the main suspect is requests and more specifically [this bug](https://github.com/kennethreitz/requests/issues/520).

Whatever the cause might be, such errors have stopped happening since applying the attached patch a month ago.
