### PR TITLE
Add docs to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@
 :Web: http://pypi.python.org/pypi/pyes/
 :Download: http://pypi.python.org/pypi/pyes/
 :Source: http://github.com/aparo/pyes/
+:Documentation: http://packages.python.org/pyes/
 :Keywords: search, elastisearch, distribute search
 
 --


### PR DESCRIPTION
The currently available docs may or may not be up to date, but at least provide a place to start. Would be helpful to have them linked from the readme.
