### PR TITLE
Fix analyzer in TextQuery

### DIFF
--- a/pyes/query.py
+++ b/pyes/query.py
@@ -1010,6 +1010,8 @@ class TextQuery(Query):
             query["operator"] = operator
         if boost != 1.0:
             query["boost"] = boost
+	if analyzer:
+	    query["analyzer"] = analyzer
 
         self.queries[field] = query
 


### PR DESCRIPTION
The 'analyzer' parameter was not getting set in method 'add_query' for class TextQuery. 
