### PR TITLE
'lang' parameter for script filters now supported

### DIFF
--- a/pyes/filters.py
+++ b/pyes/filters.py
@@ -206,11 +206,11 @@ class PrefixFilter(Filter):
 class ScriptFilter(Filter):
     _internal_name = "script"
 
-    def __init__(self, script, params=None, **kwargs):
+    def __init__(self, script, params=None, lang=None, **kwargs):
         super(ScriptFilter, self).__init__(**kwargs)
         self.script = script
         self.params = params
-
+        self.lang = lang
 
     def add(self, field, value):
         self.params[field] = {'value': value}
@@ -219,6 +219,8 @@ class ScriptFilter(Filter):
         data = {'script': self.script}
         if self.params is not None:
             data['params'] = self.params
+        if self.lang is not None:
+            data['lang'] = self.lang
         return self._add_parameters({self._internal_name: data})
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import unittest
+from .estestcase import ESTestCase
+
+
+class ScriptFilterTestCase(ESTestCase):
+
+    def test_lang(self):
+        from pyes.filters import ScriptFilter
+        f = ScriptFilter(
+            'name',
+            params={
+                'param_1': 1,
+                'param_2': 'boo',
+            },
+            lang='native'
+        )
+        expected = {
+            'script': {
+                'params': {
+                    'param_1': 1,
+                    'param_2': 'boo'},
+                'script': 'name',
+                'lang': 'native',
+            }
+        }
+        self.assertEqual(expected, f.serialize())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This allows you to, for example, use native scripts in filters.
