### PR TITLE
Allow simplejson to override json, if present. Fixes #216.

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -7,13 +7,13 @@ from .helpers import SettingsBuilder
 from .models import ElasticSearchModel, DotDict, ListBulker
 
 try:
-    # For Python >= 2.6
-    import json
-    from json import JSONDecoder, JSONEncoder
-except ImportError:
     # For Python < 2.6 or people using a newer version of simplejson
     import simplejson as json
     from simplejson import JSONDecoder, JSONEncoder
+except ImportError:
+    # For Python >= 2.6
+    import json
+    from json import JSONDecoder, JSONEncoder
 
 import random
 from datetime import date, datetime

--- a/pyes/models.py
+++ b/pyes/models.py
@@ -5,7 +5,10 @@ from __future__ import with_statement
 
 import copy
 import threading
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 from types import GeneratorType
 
 from .exceptions import BulkOperationException

--- a/pyes/query.py
+++ b/pyes/query.py
@@ -2,11 +2,11 @@
 from __future__ import absolute_import
 
 try:
-    # For Python >= 2.6
-    import json
-except ImportError:
     # For Python < 2.6 or people using a newer version of simplejson
     import simplejson as json
+except ImportError:
+    # For Python >= 2.6
+    import json
 
 from .utils import clean_string, ESRange, EqualityComparableUsingAttributeDictionary
 from .highlight import HighLighter

--- a/pyes/rivers.py
+++ b/pyes/rivers.py
@@ -2,13 +2,11 @@
 from __future__ import absolute_import
 
 try:
-    # For Python < 2.6 or people using a newer version of simplejson
-    import simplejson
-
-    json = simplejson
-except ImportError:
     # For Python >= 2.6
     import json
+except ImportError:
+    # For Python < 2.6 or people using a newer version of simplejson
+    import simplejson as json
 
 from .es import ES
 


### PR DESCRIPTION
This should fix #216. It allows simplejson to be used over the stdlib json on Python 2.7 again.
