### PR TITLE
Fixed invalid error message formatting

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -256,7 +256,7 @@ class ES(object):
         for server in self.servers:
             if isinstance(server, (tuple, list)):
                 if len(list(server)) != 3:
-                    raise RuntimeError("Invalid server definition: \"%s\"" % server)
+                    raise RuntimeError("Invalid server definition: \"%s\"" % repr(server))
                 _type, host, port = server
                 server = urlparse('%s://%s:%s' % (_type, host, port))
                 check_format(server)


### PR DESCRIPTION
In `ES._check_servers()`, if `server` is a list of size 2 or >=4,
formatting string was failing with the following exception:

```
TypeError: not all arguments converted during string formatting
```
