### PR TITLE
Make JSON encoding more resilient

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -79,9 +79,9 @@ class ESJsonEncoder(JSONEncoder):
             return dt.isoformat()
         elif isinstance(value, Decimal):
             return float(str(value))
-        # use no special encoding and hope for the best
-        return value
-
+        else:
+            # Fall back to converting the value to a string
+            return str(value)
 
 class ESJsonDecoder(JSONDecoder):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Before this change, if a document to be indexed contained a random object, there was a good chance of causing json to raise a false circular reference error, caused by the same value being passed to default over and over again, ad nauseum. After this change, an unrecognized object will simply be converted to a string representation.
