### PR TITLE
handle IOError to switch to another server

### DIFF
--- a/pyes/connection_http.py
+++ b/pyes/connection_http.py
@@ -100,7 +100,7 @@ class Connection(object):
                 return RestResponse(status=response.status,
                                     body=response.data,
                                     headers=response.headers)
-            except urllib3.exceptions.HTTPError, ex:
+            except (IOError, urllib3.exceptions.HTTPError), ex:
                 self._drop_server(server)
                 self._local.server = server = None
                 if retry >= self._max_retries:


### PR DESCRIPTION
An IOError is now handled when connecting to a server.
It will now change to another server.
