### PR TITLE
added a __nonzero__ method to the ListBulker

### DIFF
--- a/pyes/models.py
+++ b/pyes/models.py
@@ -176,6 +176,11 @@ class ListBulker(BaseBulker):
         with self.bulk_lock:
             self.bulk_data = []
 
+    def __nonzero__(self):
+        # This is needed for __del__ in ES to correctly detect if there is
+        # unsaved bulk data left over.
+        return not not self.bulk_data
+
     def add(self, content):
         with self.bulk_lock:
             self.bulk_data.append(content)


### PR DESCRIPTION
This is needed to make sure **del** in ES can detect left over bulk data.

Without this any call to **del** will log an error about unsaved bulk data.
