### PR TITLE
Deal properly with self.fields = []

### DIFF
--- a/pyes/query.py
+++ b/pyes/query.py
@@ -113,7 +113,7 @@ class Search(EqualityComparableUsingAttributeDictionary):
             res['filter'] = self.filter.serialize()
         if self.facet.facets:
             res['facets'] = self.facet.serialize()
-        if self.fields:
+        if self.fields is not None: #Deal properly with self.fields = []
             res['fields'] = self.fields
         if self.size is not None:
             res['size'] = self.size


### PR DESCRIPTION
We must distinguish self.fields = None (a value has not be set and should not be specified, allowing the defaults to be used), and self.fields = [](a value has been set indicating that no fields should be returned)
