### PR TITLE
Bugfix in setting the size to 0 in a search

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -1380,7 +1380,12 @@ class ResultSet(object):
         self.start = query_params.get("start", search.start) or 0
         self._max_item = query_params.get("size", search.size)
         self._current_item = 0
-        self.chuck_size = search.bulk_read or search.size or 10
+        if search.bulk_read is not None:
+            self.chuck_size = search.bulk_read 
+        elif search.size is not None:
+            self.chuck_size = search.size 
+        else:
+            self.chuck_size = 10
 
     def _do_search(self, auto_increment=False):
         self.iterpos = 0


### PR DESCRIPTION
setting the size in a search to 0 (not None) leads to used size of 10
in the query. This is not what it should do. If the resultset 0 is
wanted it should query it.
