### PR TITLE
Terms facet can have a script, without field or fields.  Regex requires ...

### DIFF
--- a/pyes/facets.py
+++ b/pyes/facets.py
@@ -309,13 +309,17 @@ class TermFacet(Facet):
         self.all_terms = all_terms
 
     def _serialize(self):
+        if not self.fields or not self.field or not self.script:
+            raise RuntimeError("Field, Fields or Script is required:%s" % self.order)
+
+        data = {}
         if self.fields:
-            data = {'fields': self.fields}
-        else:
-            if self.field:
-                data = {'field': self.field}
-            else:
-                raise RuntimeError("Field or Fields is required:%s" % self.order)
+            data['fields'] = self.fields
+        elif self.field:
+            data['field'] = self.field
+
+        if self.script:
+            data['script'] = self.script
         if self.size is not None:
             data['size'] = self.size
         if self.order:
@@ -324,12 +328,10 @@ class TermFacet(Facet):
             data['order'] = self.order
         if self.exclude:
             data['exclude'] = self.exclude
-        if self.regex:
+        if (self.fields or self.field) and self.regex:
             data['regex'] = self.regex
             if self.regex_flags:
                 data['regex_flags'] = self.regex_flags
-        elif self.script:
-            data['script'] = self.script
         if self.all_terms:
             data['all_terms'] = self.all_terms
         return data


### PR DESCRIPTION
...either field or fields

Slight modification to the terms facet to enable you to use it without a field/fields, if you're using a script.

Modified the regex condition to conform
