### PR TITLE
JDBC River: default for sql parameter is an empty string

### DIFF
--- a/pyes/rivers.py
+++ b/pyes/rivers.py
@@ -168,7 +168,7 @@ class JDBCRiver(River):
 
     def __init__(self, dbhost="localhost", dbport=5432, dbtype="postgresql",
                  dbname=None, dbuser=None, dbpassword=None, poll_time="5s",
-                 sql=None, name=None, params={}, **kwargs):
+                 sql="", name=None, params={}, **kwargs):
         super(JDBCRiver, self).__init__(**kwargs)
         self.dbsettings = {
                 'dbhost': dbhost,


### PR DESCRIPTION
River.serialize() raised exception on self.sql.replace, when no sql parameter was given during initialization.
