### PR TITLE
Fix for issue 317

### DIFF
--- a/pyes/managers.py
+++ b/pyes/managers.py
@@ -475,6 +475,9 @@ class Cluster(object):
                 raise ValueError("%s is not a valid delay time"%delay)
             except TypeError:
                 raise TypeError("%s is not of type int or string"%delay)
+        if not path:
+            # default action
+            path = make_path('_shutdown')
         return self.conn._send_request('GET', path)
 
 


### PR DESCRIPTION
Fix for https://github.com/aparo/pyes/issues/317

Fixes typo in shutdown procedure and adds default action to shutdown all nodes.
