### PR TITLE
No reason to forbid empty values()

### DIFF
--- a/pyes/queryset.py
+++ b/pyes/queryset.py
@@ -474,7 +474,6 @@ class QuerySet(object):
     ##################################################
 
     def values(self, *fields):
-        assert fields, "A least a field is required"
         search = self._build_search()
         search.facet.reset()
         search.fields=fields


### PR DESCRIPTION
Django queryset.values() does not force it and pyes code as well.
