### PR TITLE
Change the log level of the destructor call

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -228,7 +228,7 @@ class ES(object):
             # the Python documentation explicitly states "It is not guaranteed
             # that __del__() methods are called for objects that still exist "
             # when the interpreter exits."
-            logger.error("pyes object %s is being destroyed, but bulk "
+            logger.debug("pyes object %s is being destroyed, but bulk "
                          "operations have not been flushed. Call force_bulk()!",
                          self)
             # Do our best to save the client anyway...


### PR DESCRIPTION
The information provided from this message is not useful to anyone in
a production environment. It is incredibly spammy, as it would trigger
on every instantiated object, even if unused. It'll trash your logs
with this message for every destroyed instance.

Considering the force_bulk is called in the destructor anyway, I'd
judge DEBUG to be the correct level for this, as even INFO doesn't fit
it.
