### PR TITLE
Added a possible path of the server to the request execution

### DIFF
--- a/pyes/connection_http.py
+++ b/pyes/connection_http.py
@@ -78,14 +78,7 @@ class Connection(object):
         else:
             headers = self._headers
 
-        kwargs = dict(
-            method=Method._VALUES_TO_NAMES[request.method],
-            url=url,
-            body=request.body,
-            headers=headers,
-            timeout=self._timeout,
-        )
-
+        
         retry = 0
         server = getattr(self._local, "server", None)
         while True:
@@ -96,6 +89,14 @@ class Connection(object):
                 conn = POOL_MANAGER.connection_from_host(parse_result.hostname,
                                                          parse_result.port,
                                                          parse_result.scheme)
+                kwargs = dict(
+                    method=Method._VALUES_TO_NAMES[request.method],
+                    url=parse_result.path + url,
+                    body=request.body,
+                    headers=headers,
+                    timeout=self._timeout,
+                )
+
                 response = conn.urlopen(**kwargs)
                 return RestResponse(status=response.status,
                                     body=response.data,


### PR DESCRIPTION
There is a possibility of elasticsearch not being in the root path, and there is no way to specify this at the moment. For example, if ES is placed under `localhost:9200/whatever`, and I want to check the cluster state, the request generated by pyes will fail because it will check that in `localhost:9200/_cluster/state` and not in `localhost:9200/whatever/_cluster/state`. This pull request just use the urlparse method, to prepend the original path of the server to the request.
