### PR TITLE
Generalize the querystring_args for matching for bulk updates

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -1099,10 +1099,9 @@ class ES(object):
 
         if bulk:
             cmd = {"update": {"_index": index, "_type": doc_type, "_id": id}}
-            if 'routing' in querystring_args:
-                cmd['_routing'] = querystring_args['routing']
-            if 'percolate' in querystring_args:
-                cmd['percolate'] = querystring_args['percolate']
+            for arg in ("routing", "percolate", "retry_on_conflict"):
+                if arg in querystring_args:
+                    cmd['_%s' % arg] = querystring_args[arg]
 
             command = "%s\n%s" % (json.dumps(cmd, cls=self.encoder), json.dumps(body, cls=self.encoder))
             self.bulker.add(command)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -134,6 +134,14 @@ class IndexingTestCase(ESTestCase):
         self.assertResultContains(result._meta,
                 {"index": "test-index", "type": "test-type", "id": "1"})
 
+        # Test bulk update
+        self.conn.update(self.index_name, self.document_type, 1, document={"name": "Christian The Hacker", "age": 24}, bulk=True)
+        self.conn.refresh(self.index_name)
+        result = self.conn.get(self.index_name, self.document_type, 1)
+        self.assertResultContains(result, {"name": "Christian The Hacker", "sex": "male", "age": 24})
+        self.assertResultContains(result._meta,
+                {"index": "test-index", "type": "test-type", "id": "1"})
+
     def testUpdateUsingFunc(self):
         def update_list_values(current, extra):
             for k, v in extra.iteritems():


### PR DESCRIPTION
I forgot to add 'retry_on_conflict', which I also need, so I generalized the handling a bit to make it easier to add more. 

Also added a quick test for bulk update.
