### PR TITLE
Bulk create throws invalid BulkOperationException

### DIFF
--- a/pyes/models.py
+++ b/pyes/models.py
@@ -211,6 +211,8 @@ class ListBulker(BaseBulker):
 
 
 def _is_bulk_item_ok(item):
+    if "create" in item:
+        return "ok" in item["create"]
     if "index" in item:
         return "ok" in item["index"]
     elif "delete" in item:


### PR DESCRIPTION
When using:

``` python
es.index(doc, ELASTICSEARCH_INDEX, document_type, bulk=True,  force_insert=True)
es.flush_bulk(forced=True)
```

This was throwing a invalid BulkOperationException exception.

P.S. elasticsearch version 0.90.6
