### PR TITLE
Fix bug where mappings with index_options break mappings

### DIFF
--- a/pyes/mappings.py
+++ b/pyes/mappings.py
@@ -45,7 +45,8 @@ class AbstractField(object):
                  analyzer=None,
                  index_analyzer=None,
                  search_analyzer=None,
-                 name=None):
+                 name=None,
+                 **kwargs):
         self.store = to_bool(store)
         self.boost = boost
         self.term_vector = term_vector


### PR DESCRIPTION
This is a bit of a band-aid.  We should add index_options as an actual keyword argument and instance attribute (and anywhere else appropriate).  However given that the mapping attributes can change, we should keep **kwargs to prevent future breakage
