### PR TITLE
Fix some Python2 backwards-incompatibility issues

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -1578,3 +1578,6 @@ class ResultSetMulti(object):
             return res
 
         raise StopIteration
+
+    if not is_py3:
+        next = __next__


### PR DESCRIPTION
We want pyes to still work with Python 2.7, right? :)
