### PR TITLE
Backwards compatibility for python < 3

### DIFF
--- a/pyes/utils/__init__.py
+++ b/pyes/utils/__init__.py
@@ -14,7 +14,7 @@ import six
 __all__ = ['clean_string', "ESRange", "ESRangeOp", "string_b64encode", "string_b64decode", "make_path", "make_id"]
 
 def quote(value):
-    value = value.encode('utf8', errors='ignore') if isinstance(value,  six.string_types) else str(value)
+    value = value.encode('utf8', 'ignore') if isinstance(value,  six.string_types) else str(value)
     return _quote(value, safe='')
 
 def make_id(value):


### PR DESCRIPTION
Python 2.6 doesn't support keyword arguments for str.encode.  Positional arguments work for both Python 2 and 3.

Python 2.6.6 Example of error stacktrace 

```
  File "/usr/lib/python2.6/site-packages/pyes/es.py", line 1059, in count
    path = self._make_path(indices, doc_types, "_count")
  File "/usr/lib/python2.6/site-packages/pyes/es.py", line 434, in _make_path
    return make_path(','.join(indices), ','.join(doc_types), *components)
  File "/usr/lib/python2.6/site-packages/pyes/utils/__init__.py", line 37, in make_path
    path_components = [quote(component) for component in path_components if component]
  File "/usr/lib/python2.6/site-packages/pyes/utils/__init__.py", line 17, in quote
    value = value.encode('utf8', errors='ignore') if isinstance(value,  six.string_types) else str(value)
TypeError: encode() takes no keyword arguments
```
