### PR TITLE
Backwards compatibility for python < 3

### DIFF
--- a/pyes/utils/__init__.py
+++ b/pyes/utils/__init__.py
@@ -24,7 +24,7 @@ def make_id(value):
     :return: a string
     """
     if isinstance(value, six.string_types):
-        value=value.encode("utf8", errors="ignore")
+        value=value.encode("utf8", "ignore")
     from hashlib import md5
     val = uuid.UUID(bytes=md5(value).digest(), version=4)
 


### PR DESCRIPTION
Python 2.6 doesn't support keyword arguments for str.encode. Positional arguments work for both Python 2 and 3.  Missed one.
