### PR TITLE
Allow native scripts in term facets

### DIFF
--- a/pyes/facets.py
+++ b/pyes/facets.py
@@ -312,7 +312,7 @@ class TermFacet(Facet):
 
     def __init__(self, field=None, fields=None, name=None, size=10, order=None,
                  exclude=None, regex=None, regex_flags="DOTALL", script=None,
-                 all_terms=None, **kwargs):
+                 lang=None, all_terms=None, **kwargs):
         super(TermFacet, self).__init__(name or field, **kwargs)
         self.field = field
         self.fields = fields
@@ -322,6 +322,7 @@ class TermFacet(Facet):
         self.regex = regex
         self.regex_flags = regex_flags
         self.script = script
+        self.lang = lang
         self.all_terms = all_terms
 
     def _serialize(self):
@@ -336,6 +337,8 @@ class TermFacet(Facet):
 
         if self.script:
             data['script'] = self.script
+            if self.lang:
+                data['lang'] = self.lang
         if self.size is not None:
             data['size'] = self.size
         if self.order:


### PR DESCRIPTION
For a given use case, we do some string-processing on a field that we want to use for faceting. This can be achieved using facet scripts, as documented [here](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-facet.html#_term_scripts)

In our case, we use a **native** script for this, but if you try to pass the lang parameter to the Facet constructor and execute the query, you get something like:

```
ElasticSearchException: PropertyAccessException[[Error: unresolvable property or identifier: sizefilter]
[Near : {... sizefilter ....}]
             ^
[Line: 1, Column: 1]]; }]
```

This has been tested with elasticsearch v0.90.2 and the pyes v20.0
