### PR TITLE
add parameter to set SSL certificate validation policy

### DIFF
--- a/pyes/connection_http.py
+++ b/pyes/connection_http.py
@@ -25,9 +25,11 @@ DEFAULT_SERVER = ("http", "127.0.0.1", 9200)
 
 POOLS = {}
 
+CERT_REQS = 'CERT_OPTIONAL'
+
 def get_pool():
     if not current_process() in POOLS:
-        POOLS[current_process()] = urllib3.PoolManager()
+        POOLS[current_process()] = urllib3.PoolManager(cert_reqs=CERT_REQS)
     return POOLS[current_process()]
 
 def update_connection_pool(maxsize=1):

--- a/pyes/es.py
+++ b/pyes/es.py
@@ -24,6 +24,7 @@ except ImportError:
     import json
 
 from . import logger
+from . import connection_http
 from .connection_http import connect as http_connect
 from .convert_errors import raise_if_error
 #from .decorators import deprecated
@@ -138,7 +139,8 @@ class ES(object):
                  basic_auth=None,
                  raise_on_bulk_item_failure=False,
                  document_object_field=None,
-                 bulker_class=ListBulker):
+                 bulker_class=ListBulker,
+                 cert_reqs='CERT_OPTIONAL'):
         """
         Init a es object.
         Servers can be defined in different forms:
@@ -203,6 +205,8 @@ class ES(object):
                                    raise_on_bulk_item_failure=raise_on_bulk_item_failure)
         self.bulker_class = bulker_class
         self._raise_on_bulk_item_failure = raise_on_bulk_item_failure
+
+        connection_http.CERT_REQS = cert_reqs
 
         self.info = {}  #info about the current server
         if encoder:


### PR DESCRIPTION
currently it is not possible to connect to HTTPS servers which present unverifiable / invalid SSL certificates
there are some use cases where this might be desirable though, e.g. to do quick tests

could you please have a look at my request ? :-)
