### PR TITLE
typoo in ensure_index causing exception

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -501,7 +501,7 @@ class ES(object):
         if exists and not mappings and not clear:
             return
         if exists and clear:
-            self.indices.indices.delete_index(index)
+            self.indices.delete_index(index)
             exists = False
 
         if exists:


### PR DESCRIPTION
Fixes error `'Indices' object has no attribute 'indices'` when `connection.ensure_index(..., clear=True)` is called and the index already exists.
