### PR TITLE
raise_on_bulk_item_failure not working with ES 1.0

### DIFF
--- a/pyes/models.py
+++ b/pyes/models.py
@@ -230,7 +230,7 @@ def _is_bulk_item_ok(item):
         if 'ok' in item['delete']:
             return True
         elif 'status' in item['delete']:
-            return item['delete']['stats'] in [200,201]
+            return item['delete']['status'] in [200,201]
         else:
             return False
     else:


### PR DESCRIPTION
From http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/_return_values.html , "ok" has been removed from all response values for ES 1.0. is_bulk_item_okay() is still checking for "ok" in the response. So, if raise_on_bulk_item_failure is set to true, pyes bulk inserts/deletes/etc are reporting as failed even if they are succeeding. 

Modified is_bulk_item_okay to check for both new and old response types.
