### PR TITLE
Allow both ends of range to be specified in ESRangeOp

### DIFF
--- a/pyes/utils/__init__.py
+++ b/pyes/utils/__init__.py
@@ -105,20 +105,21 @@ class ESRange(EqualityComparableUsingAttributeDictionary):
 
 
 class ESRangeOp(ESRange):
-    def __init__(self, field, op, value, boost=None):
+    def __init__(self, field, op1, value1, op2=None, value2=None, boost=None):
         from_value = to_value = include_lower = include_upper = None
-        if op == "gt":
-            from_value = value
-            include_lower = False
-        elif op == "gte":
-            from_value = value
-            include_lower = True
-        if op == "lt":
-            to_value = value
-            include_upper = False
-        elif op == "lte":
-            to_value = value
-            include_upper = True
+        for op, value in ((op1, value1), (op2, value2)):
+            if op == "gt":
+                from_value = value
+                include_lower = False
+            elif op == "gte":
+                from_value = value
+                include_lower = True
+            if op == "lt":
+                to_value = value
+                include_upper = False
+            elif op == "lte":
+                to_value = value
+                include_upper = True
         super(ESRangeOp, self).__init__(field, from_value, to_value,
             include_lower, include_upper, boost)
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -363,6 +363,8 @@ class QuerySearchTestCase(ESTestCase):
             ESRangeOp("foo", "gt", 5))
         self.assertEqual(ESRangeOp("bar", "lt", 6),
             ESRangeOp("bar", "lt", 6))
+        self.assertEqual(ESRangeOp("bar", "gt", 3, "lt", 6),
+            ESRangeOp("bar", "lt", 6, "gt", 3))
 
     def test_RawFilter_dict(self):
         filter_ = dict(ids=dict(type="my_type", values=["1", "4", "100"]))


### PR DESCRIPTION
Currently, if you want to use new-style ranges, you have to awkwardly combine two of them, like shown [here](https://gist.github.com/dlemphers/1553581). This patch allows defining both ends of the range in one operator.

I'm not sure what kind of emphasis this project has on backwards compatibility, but if someone has code calling the `ESRangeOp` constructor with the boost parameter used by position, this will cause them problems. You can add a line testing whether `op2` is a number, and if so assign it to `boost` or throw an Exception. Or you can reject the PR altogether. I won't be offended.

(Personally I think usage of the boost parameter is too rare to worry about).
