### PR TITLE
Handle servers specified as unicode literals

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -209,7 +209,7 @@ class ES(object):
             self.encoder = encoder
         if decoder:
             self.decoder = decoder
-        if isinstance(server, str):
+        if isinstance(server, basestring):
             self.servers = [server]
         elif isinstance(server, tuple):
             self.servers = [server]
@@ -266,7 +266,7 @@ class ES(object):
                 _type, host, port = server
                 server = urlparse('%s://%s:%s' % (_type, host, port))
                 check_format(server)
-            elif isinstance(server, str):
+            elif isinstance(server, basestring):
                 if server.startswith(("thrift:", "http:", "https:")):
                     server = urlparse(server)
                     check_format(server)


### PR DESCRIPTION
So far `ES._check_server()` checked whether the given server was an instance of
`str`. This fails in case the server was specified as a unicode literal.

This commit checks whether the given server is an instance of `basestring`
instead of `str` to cover `unicode` objects as well.

Fixes #376.

NOTE: There are more occurences of `isinstance(var, str)` which I haven't come across yet, but which should probably be touched nevertheless.
