### PR TITLE
 fix import OrderedDict

### DIFF
--- a/pyes/mappings.py
+++ b/pyes/mappings.py
@@ -2,7 +2,10 @@
 
 
 import threading
+from collections import OrderedDict
 from .models import SortedDict, DotDict
+
+
 
 _thread_locals = threading.local()
 #store threadsafe data


### PR DESCRIPTION
OrderedDict is used in mappings.py without previously importing it . I'm suspecting there's some compatibility thing I'm missing , but just in case, there you have this. 
