### PR TITLE
  indices.get_mapping adapted to the new response from ES1.10

### DIFF
--- a/pyes/managers.py
+++ b/pyes/managers.py
@@ -441,7 +441,8 @@ class Indices(object):
         if raw:
             return result
         from pyes.mappings import Mapper
-        mapper = Mapper(result, is_mapping=is_mapping, connection=self.conn,
+        mapper = Mapper(result['mappings'], is_mapping=is_mapping,
+                        connection=self.conn,
                         document_object_field=self.conn.document_object_field)
         if doc_type:
             return mapper.mappings[doc_type]


### PR DESCRIPTION
when asking for mapping info to ES (http://localhost:9200/my_index/_mapping) an extra "mappings" key is added on top of the response.
