### PR TITLE
Allow different search types in Multisearch queries

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -1673,7 +1673,7 @@ class EmptyResultSet(object):
 
 class ResultSetMulti(object):
     def __init__(self, connection, searches, indices_list=None,
-                 doc_types_list=None, routing_list=None, models=None):
+                 doc_types_list=None, routing_list=None, search_type_list=None, models=None):
         """
         results: an es query results dict
         fix_keys: remove the "_" from every key, useful for django views
@@ -1701,6 +1701,10 @@ class ResultSetMulti(object):
             self.routing_list = [None] * num_searches
         else:
             self.routing_list = routing_list
+        if search_type_list is None:
+            self.search_type_list = [None] * num_searches
+        else:
+            self.search_type_list = search_type_list
         self._results_list = None
         self.models = models or self.connection.model
         self._total = None
@@ -1742,7 +1746,8 @@ class ResultSetMulti(object):
     def _search_raw_multi(self):
         self.multi_search_query, result = self.connection.search_raw_multi(
             self.searches, indices_list=self.indices_list,
-            doc_types_list=self.doc_types_list, routing_list=self.routing_list)
+            doc_types_list=self.doc_types_list, routing_list=self.routing_list,
+            search_type_list=self.search_type_list)
 
         return result
 
@@ -1789,3 +1794,4 @@ class ResultSetMulti(object):
 
     if six.PY2:
         next = __next__
+


### PR DESCRIPTION
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html#_parameters_4
The `search_type` can't be in the search request body. 

The default search_type is `query_then_fetch` (http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-search-type.html#query-then-fetch), and this will also be the one running by default in multisearch queries

The tests pass without issues
