### PR TITLE
Fix a race condition on index' doc count retrieval

### DIFF
--- a/pyes/managers.py
+++ b/pyes/managers.py
@@ -218,8 +218,12 @@ class Indices(object):
         indices_metadata = state['metadata']['indices']
         for index in sorted(indices_status.keys()):
             info = indices_status[index]
-            num_docs = info['docs']['num_docs']
+            try:
+                num_docs = info['docs']['num_docs']
+            except KeyError:
+                num_docs = 0
             result[index] = dict(num_docs=num_docs)
+
             if not include_aliases:
                 continue
             try:


### PR DESCRIPTION
managers.Indices.get_indices() could fail (and raise a KeyError) upon
reading the 'num_docs' of an index just created. Catching the exception
and setting the 'num_docs' to 0 (which is the actual value) fixes the
problem.

This fixes issue #401.
