### PR TITLE
Add test case and bug fix for double serialization of delete_by_query qu...

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -912,7 +912,7 @@ class ES(object):
         Delete documents from one or more indices and one or more types based on a query.
         """
         path = self._make_path(indices, doc_types, '_query')
-        body = {"query": self._encode_query(query)}
+        body = {"query": query.serialize()}
         return self._send_request('DELETE', path, body, query_params)
 
     def exists(self, index, doc_type, id, **query_params):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -543,5 +543,12 @@ class QuerySearchTestCase(ESTestCase):
 
         self.assertEqual(resultset.hits[0]['_score'], 20)
 
+    def test_DeleteByQuery(self):
+        q = TermQuery("name", "joe")
+        result = self.conn.delete_by_query(self.index_name,
+            [self.document_type], q)
+        self.assertEqual(result['_indices'][self.index_name]
+            ['_shards']['failed'], 0)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes a serialization bug in the delete_by_query method for the upgrade to elasticsearch 1.x.x. The fix avoids calling `json.dumps` twice on the query and causing a malformed query exception from elasticsearch. 
