### PR TITLE
Fix for python 2.x compatible unicode encoding of strings

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -36,7 +36,7 @@ from .mappings import Mapper
 from .models import ElasticSearchModel, DotDict, ListBulker
 from .query import Search, Query
 from .rivers import River
-from .utils import make_path
+from .utils import make_path, get_unicode_string
 
 try:
     from .connection import connect as thrift_connect
@@ -527,7 +527,7 @@ class ES(object):
         body = request.body
         if body:
             if not isinstance(body, str):
-                body = str(body, "utf8")
+                body = get_unicode_string(body)
             curl_cmd += " -d '%s'" % body
         return curl_cmd
 

--- a/pyes/utils/__init__.py
+++ b/pyes/utils/__init__.py
@@ -161,3 +161,10 @@ def keys_to_string(data):
                 del data[key]
                 data[key.encode("utf8", "ignore")] = val
     return data
+
+def get_unicode_string(string):
+  try:
+    return str(string, 'utf8')
+  except TypeError: # python 2.x compatible
+    return unicode(string)
+


### PR DESCRIPTION
Fixes a bug where a `TypeError` is thrown in python 2.x since the `str` constructor takes at most 1 argument before python 3.x. 
