### PR TITLE
Add ignore_conflicts parameter to put_mapping

### DIFF
--- a/pyes/managers.py
+++ b/pyes/managers.py
@@ -403,7 +403,7 @@ class Indices(object):
         path = self.conn._make_path(indices, (), '_gateway', 'snapshot')
         return self.conn._send_request('POST', path)
 
-    def put_mapping(self, doc_type=None, mapping=None, indices=None):
+    def put_mapping(self, doc_type=None, mapping=None, indices=None, ignore_conflicts=None):
         """
         Register specific mapping definition for a specific type against one or more indices.
         (See :ref:`es-guide-reference-api-admin-indices-put-mapping`)
@@ -422,7 +422,12 @@ class Indices(object):
         else:
             path = self.conn._make_path(indices, (), "_mapping")
 
-        return self.conn._send_request('PUT', path, mapping)
+        parameters = {}
+
+        if ignore_conflicts is not None:
+            parameters['ignore_conflicts'] = ignore_conflicts
+
+        return self.conn._send_request('PUT', path, mapping, params=parameters)
 
     def get_mapping(self, doc_type=None, indices=None, raw=False):
         """


### PR DESCRIPTION
as stated in the elasticsearch documentation:
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html

> When an existing mapping already exists under the given type, the two mapping definitions, the one already defined, and the new ones are merged. The `ignore_conflicts` parameters can be used to control if conflicts should be ignored or not, by default, it is set to `false` which means conflicts are not ignored.

this was not implemented yet in PyES, or I didn't find it?
