### PR TITLE
Fixed a typo in MongoDBRiver

### DIFF
--- a/pyes/rivers.py
+++ b/pyes/rivers.py
@@ -218,7 +218,7 @@ class MongoDBRiver(River):
             "filter": filter
         }
 
-    def serialize(self):
+    def _serialize(self):
         result = {
             'type': self.type,
             'mongodb': self.mongodb


### PR DESCRIPTION
Changed from serialize method name to _serialize. Without this, the MongoDB river won't be created.
