### PR TITLE
Changes to be able to use Child/Parent mapping with MongoDB river

### DIFF
--- a/pyes/aggs.py
+++ b/pyes/aggs.py
@@ -378,7 +378,13 @@ class TermsAgg(BucketAgg):
         if self.order:
             if self.order not in ['count', 'term', 'reverse_count', 'reverse_term']:
                 raise RuntimeError("Invalid order value:%s" % self.order)
-            data['order'] = self.order
+            data['order'] = {
+            }
+            if self.order.startswith('reverse_'):
+                # Remove reverse
+                data['order'][self.order[7:]] = 'desc' if 'term' in self.order else 'asc'
+            else:
+                data['order']['_' + self.order] = 'asc' if 'term' in self.order else 'desc'
         if self.exclude:
             data['exclude'] = self.exclude
         if (self.fields or self.field) and self.regex:

--- a/pyes/query.py
+++ b/pyes/query.py
@@ -536,16 +536,19 @@ class ConstantScoreQuery(Query):
 
 class HasQuery(Query):
 
-    def __init__(self, type, query, _scope=None, **kwargs):
+    def __init__(self, type, query, _scope=None, score_mode=None, **kwargs):
         super(HasQuery, self).__init__(**kwargs)
         self.type = type
         self._scope = _scope
+        self.score_mode = score_mode
         self.query = query
 
     def _serialize(self):
         data = {'type': self.type, 'query': self.query.serialize()}
         if self._scope is not None:
             data['_scope'] = self._scope
+        if self.score_mode is not None:
+            data['score_mode'] = self.score_mode
         return data
 
 
@@ -553,10 +556,20 @@ class HasChildQuery(HasQuery):
 
     _internal_name = "has_child"
 
+    def __init__(self, *args, **kwargs):
+        super(HasChildQuery, self).__init__(*args, **kwargs)
+        if self.score_mode and self.score_mode not in ["max", "sum", "avg", "none"]:
+            raise InvalidParameterQuery("Invalid value '%s' for score_mode" % self.score_mode)
+
 
 class HasParentQuery(HasQuery):
 
     _internal_name = "has_parent"
+
+    def __init__(self, *args, **kwargs):
+        super(HasParentQuery, self).__init__(*args, **kwargs)
+        if self.score_mode and self.score_mode not in ["score", "none"]:
+            raise InvalidParameterQuery("Invalid value '%s' for score_mode" % self.score_mode)
 
 
 class TopChildrenQuery(ConstantScoreQuery):

--- a/pyes/rivers.py
+++ b/pyes/rivers.py
@@ -204,7 +204,7 @@ class MongoDBRiver(River):
     type = "mongodb"
 
     def __init__(self, servers, db, collection, index_name, mapping_type, gridfs=False, options=None, bulk_size=1000,
-                 filter=None, **kwargs):
+                 filter=None, script=None, **kwargs):
         super(MongoDBRiver, self).__init__(**kwargs)
         self.name = index_name
         self.index_type = mapping_type
@@ -217,6 +217,8 @@ class MongoDBRiver(River):
             "gridfs": gridfs,
             "filter": filter
         }
+        if script:
+          self.mongodb['script'] = script
 
     def _serialize(self):
         result = {


### PR DESCRIPTION
Together with adding script parameter to MongoDB river and adding score_mode parameter to has parent/child queries, I've also changed the serialization of order parameter in TermsAgg to be compliant with ES 1.2.x (by keeping the same values).