### PR TITLE
Allow query_weight and rescore_query_weight to be zero.

### DIFF
--- a/pyes/query.py
+++ b/pyes/query.py
@@ -1623,9 +1623,9 @@ class RescoreQuery(Query):
         """Serialize the query to a structure using the query DSL."""
 
         data = {self._internal_name: self.query.serialize()}
-        if self.query_weight:
+        if self.query_weight is not None:
             data['query_weight'] = self.query_weight
-        if self.rescore_query_weight:
+        if self.rescore_query_weight is not None:
             data['rescore_query_weight'] = self.rescore_query_weight
 
         return data


### PR DESCRIPTION
It should be possible to legitimately set one or both of these to zero.

They are set to 1 by default: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-rescore.html
