### PR TITLE
Make sure we BoostFunction can be serialized without filter

### DIFF
--- a/pyes/query.py
+++ b/pyes/query.py
@@ -1748,10 +1748,10 @@ class FunctionScoreQuery(Query):
             self.filter = filter
 
         def serialize(self):
-            return {
-                self._internal_name: self.boost_factor,
-                'filter': self.filter.serialize()
-            }
+            data = {self._internal_name: self.boost_factor}
+            if self.filter:
+                data['filter'] = self.filter.serialize()
+            return data
 
     class RandomFunction(FunctionScoreFunction):
         """Is a random boost based on a seed value"""

--- a/pyes/query.py
+++ b/pyes/query.py
@@ -245,7 +245,7 @@ class Search(EqualityComparableUsingAttributeDictionary):
             res['rescore'] = self.rescore.serialize()
         if self.window_size:
             res['window_size'] = self.window_size
-        if self.fields is not None: #Deal properly with self.fields = []
+        if self.fields is not None:  # Deal properly with self.fields = []
             res['fields'] = self.fields
         if self.size is not None:
             res['size'] = self.size
@@ -658,7 +658,7 @@ class DisMaxQuery(Query):
             raise InvalidQuery("A least a query is required")
         return filters
 
-#Removed in ES 1.x
+# Removed in ES 1.x
 # class FieldQuery(Query):
 #
 #     _internal_name = "field"
@@ -1260,7 +1260,7 @@ class QueryStringQuery(Query):
                 raise InvalidQuery("The query is empty")
             filters["query"] = self.query
         if self.minimum_should_match:
-          filters['minimum_should_match']=self.minimum_should_match
+          filters['minimum_should_match'] = self.minimum_should_match
         return filters
 
 class SimpleQueryStringQuery(Query):
@@ -1713,7 +1713,7 @@ class FunctionScoreQuery(Query):
 
     class DecayFunction(FunctionScoreFunction):
 
-        def __init__(self, decay_function, field, origin, scale,  decay=None, offset=None, filter=None):
+        def __init__(self, decay_function, field, origin=None, scale=None, decay=None, offset=None, filter=None):
 
             decay_functions = ["gauss", "exp", "linear"]
             if decay_function not in decay_functions:
@@ -1729,11 +1729,13 @@ class FunctionScoreQuery(Query):
             self.offset = offset
 
         def _serialize(self):
-
-            field_data = {'origin': self.origin, 'scale': self.scale}
+            field_data = {}
+            if self.origin is not None:
+                field_data['origin'] = self.origin
+            if self.scale is not None:
+                field_data['scale'] = self.scale
             if self.decay:
                 field_data['decay'] = self.decay
-
             if self.offset:
                 field_data['offset'] = self.offset
 

--- a/pyes/query.py
+++ b/pyes/query.py
@@ -245,7 +245,7 @@ class Search(EqualityComparableUsingAttributeDictionary):
             res['rescore'] = self.rescore.serialize()
         if self.window_size:
             res['window_size'] = self.window_size
-        if self.fields is not None:  # Deal properly with self.fields = []
+        if self.fields is not None: #Deal properly with self.fields = []
             res['fields'] = self.fields
         if self.size is not None:
             res['size'] = self.size
@@ -658,7 +658,7 @@ class DisMaxQuery(Query):
             raise InvalidQuery("A least a query is required")
         return filters
 
-# Removed in ES 1.x
+#Removed in ES 1.x
 # class FieldQuery(Query):
 #
 #     _internal_name = "field"
@@ -1260,7 +1260,7 @@ class QueryStringQuery(Query):
                 raise InvalidQuery("The query is empty")
             filters["query"] = self.query
         if self.minimum_should_match:
-          filters['minimum_should_match'] = self.minimum_should_match
+          filters['minimum_should_match']=self.minimum_should_match
         return filters
 
 class SimpleQueryStringQuery(Query):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -549,6 +549,11 @@ class QuerySearchTestCase(ESTestCase):
         resultset = self.conn.search(query=q)
         self.assertEqual(resultset.hits[0]['_score'], 6.0)
 
+    def test_FunctionScoreQuery_BoostFunction(self):
+        function = FunctionScoreQuery.BoostFunction(2)
+        serialized = function.serialize()
+        self.assertEqual(serialized, {"boost_factor": 2})
+
     def test_DeleteByQuery(self):
         q = TermQuery("name", "joe")
         result = self.conn.delete_by_query(self.index_name,

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -554,6 +554,11 @@ class QuerySearchTestCase(ESTestCase):
         serialized = function.serialize()
         self.assertEqual(serialized, {"boost_factor": 2})
 
+    def test_FunctionScoreQuery_DecayFunction(self):
+        function = FunctionScoreQuery.DecayFunction("gauss", "timestamp", scale="4w")
+        serialized = function.serialize()
+        self.assertEqual(serialized, {"gauss": {"timestamp": {"scale": "4w"}}})
+
     def test_DeleteByQuery(self):
         q = TermQuery("name", "joe")
         result = self.conn.delete_by_query(self.index_name,


### PR DESCRIPTION
The filter is optional in the BoostFunction, but serialization failed when it was None.