### PR TITLE
Fix for wrong error message when the connect string contains non-inte…

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -336,7 +336,7 @@ class ES(object):
                         try:
                             port = int(tokens[1])
                         except ValueError:
-                            raise RuntimeError("Invalid port: \"%s\"" % port)
+                            raise RuntimeError("Invalid port: \"%s\"" % tokens[1])
 
                         if 9200 <= port <= 9299:
                             _type = "http"


### PR DESCRIPTION
…ger port

Described the issue in issue #490.

After fix, the trace back will be:

Traceback (most recent call last):
  File "test.py", line 4, in <module>
    es = ES(conn_str)
  File "/home/ravi/tmp/pyes/es.py", line 283, in __init__
    self._check_servers()
  File "/home/ravi/tmp/pyes/es.py", line 339, in _check_servers
    raise RuntimeError("Invalid port: \"%s\"" % tokens[1])
RuntimeError: Invalid port: "abcd"
