### PR TITLE
Added Cardinality Aggregations

### DIFF
--- a/pyes/aggs.py
+++ b/pyes/aggs.py
@@ -385,42 +385,25 @@ class TermsAgg(BucketAgg):
         self.all_terms = all_terms
         self.min_doc_count = int(min_doc_count) if min_doc_count else None
 
+class CardinalityAgg(Agg):
+
+    _internal_name = "cardinality"
+
+    def __init__(self, name, field=None, precision_threshold=100, **kwargs):
+        super(CardinalityAgg, self).__init__(name, **kwargs)
+        self.field = field
+        if precision_threshold > 40000:
+            precision_threshold = 40000
+        self.precision_threshold = precision_threshold
+
+
     def _serialize(self):
-        if not self.fields and not self.field and not self.script:
-            raise RuntimeError("Field, Fields or Script is required:%s" % self.order)
+        if not self.field:
+            raise RuntimeError("Field is required:%s" % self.order)
 
         data = {}
-        if self.fields:
-            data['fields'] = self.fields
-        elif self.field:
-            data['field'] = self.field
-
-        if self.script:
-            data['script'] = self.script
-            if self.lang:
-                data['lang'] = self.lang
-        if self.size is not None:
-            data['size'] = self.size
-        if self.order:
-            if self.order not in ['count', 'term', 'reverse_count', 'reverse_term']:
-                raise RuntimeError("Invalid order value:%s" % self.order)
-            data['order'] = {
-            }
-            if self.order.startswith('reverse_'):
-                # Remove reverse
-                data['order'][self.order[7:]] = 'desc' if 'term' in self.order else 'asc'
-            else:
-                data['order']['_' + self.order] = 'asc' if 'term' in self.order else 'desc'
-        if self.exclude:
-            data['exclude'] = self.exclude
-        if (self.fields or self.field) and self.regex:
-            data['regex'] = self.regex
-            if self.regex_flags:
-                data['regex_flags'] = self.regex_flags
-        if self.all_terms:
-            data['all_terms'] = self.all_terms
-        if self.min_doc_count:
-            data['min_doc_count'] = self.min_doc_count
+        data['field'] = self.field
+        data['precision_threshold'] = self.precision_threshold
         return data
 
 


### PR DESCRIPTION
Seems like a missing functionality. Only one parameter exists, that is precision_threshold. A very simple aggregation. One of the uses is to approximate number of unique values in a set
GET /index-name/vote/_search
{
  "size": 0, 
  "aggs" : {
      "unique_users" : {
          "cardinality" : {
              "field" : "user_id"
          }
      }
  }
}