### PR TITLE
Add Python 3.x bool() support

### DIFF
--- a/pyes/models.py
+++ b/pyes/models.py
@@ -144,6 +144,9 @@ class BaseBulker(object):
             self.bulk_data = []
         self.raise_on_bulk_item_failure = raise_on_bulk_item_failure
 
+    def __bool__(self):
+        return self.__nonzero__()
+
     def get_bulk_size(self):
         """
         Get the current bulk_size

--- a/pyes/orm/queryset.py
+++ b/pyes/orm/queryset.py
@@ -265,6 +265,8 @@ class QuerySet(object):
         # iterating over the cache.
         return iter(self._result_cache)
 
+    def __bool__(self):
+        return self.__nonzero__()
 
     def __nonzero__(self):
         if self._result_cache is not None:

--- a/pyes/queryset.py
+++ b/pyes/queryset.py
@@ -188,6 +188,9 @@ class QuerySet(object):
 #            if len(self._result_cache) <= pos:
 #                self._fill_cache()
 
+    def __bool__(self):
+        return self.__nonzero__()
+
     def __nonzero__(self):
         if self._result_cache is not None:
             len(self)


### PR DESCRIPTION
This fixes a small issue in python 3.x. On line 293 of `pyes.ES.__del__`, the magicmethod for bool in Python 3 wasn't defined, so the "if self.bulker" check always passes, so every time a pyes.ES object is garbage collected a message is logged at error level and a useless flush_bulk(True) is called. I think this is what's behind issue 458.

I also fixed the 2 other places that defined `__nonzero__` but not `__bool__` while I was at it.