### PR TITLE
pypy failure fix on fastbinary import with "AttributeError"

### DIFF
--- a/pyes/pyesthrift/Rest.py
+++ b/pyes/pyesthrift/Rest.py
@@ -12,7 +12,7 @@ from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 try:
   from thrift.protocol import fastbinary
-except ImportError:
+except:
   fastbinary = None
 
 

--- a/pyes/pyesthrift/ttypes.py
+++ b/pyes/pyesthrift/ttypes.py
@@ -10,7 +10,7 @@ from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 try:
   from thrift.protocol import fastbinary
-except ImportError:
+except:
   fastbinary = None
 
 


### PR DESCRIPTION
we hit this bug when we are using this library with pypy:

> Traceback (most recent call last):
>   File "/venv/pypy/site-packages/commons/app.py", line 251, in run
>     main()
>   File "/repo/start.py", line 14, in start_daemon
>     import configuration
>   File "/repo/configuration.py", line 14, in <module>
>     from pyes import ES
>   File "/venv/pypy/site-packages/pyes/__init__.py", line 26, in <module>
>     from .es import ES, file_to_attachment
>   File "/venv/pypy/site-packages/pyes/es.py", line 41, in <module>
>     from .connection import connect as thrift_connect
>   File "/venv/pypy/site-packages/pyes/connection.py", line 12, in <module>
>     from .pyesthrift import Rest
>   File "/venv/pypy/site-packages/pyes/pyesthrift/Rest.py", line 9, in <module>
>     from .ttypes import *
>   File "/venv/pypy/site-packages/pyes/pyesthrift/ttypes.py", line 12, in <module>
>     from thrift.protocol import fastbinary
> AttributeError: 'module' object has no attribute 'cStringIO_CAPI'

we assumed that the bug is due to this issue in pypy:

https://bitbucket.org/pypy/pypy/issues/875/thrift-installation-error-cstringioh