### PR TITLE
fixed inconsistent use to QuerySet

### DIFF
--- a/pyes/queryset.py
+++ b/pyes/queryset.py
@@ -332,7 +332,7 @@ class QuerySet(object):
         and returning the created object.
         """
         obj = self.model(**kwargs)
-	meta = obj.get_meta()
+        meta = obj.get_meta()
         meta.connection = get_es_connection(self.es_url, self.es_kwargs)
         meta.index=self.index
         meta.type=self.type


### PR DESCRIPTION
it would raise an Error under python3.3
the line 335:
    meta = obj.get_meta()
                        ^
TabError: inconsistent use of tabs and spaces in indentation